### PR TITLE
Update to 2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,845 +2,787 @@
 
 ## Next Version
 
+#### Fixed
+
+- Fixed an issue where DocC was not added to source file list #1202 @hiragram
+
+## 2.28.0
+
+#### Added
+
+- Support for specifying custom group locations for SPM packages. #1173 @John-Connolly 
+
+### Fixed
+
+- Fix Monterey macOS shell version, shell login flag for environments #1167 @bimawa
+- Fixed crash caused by a simultaneous write during a glob processing #1177 @tr1ckyf0x
+
+### Changed
+
+- Run target source pattern matching in parallel #1197 @alvarhansen
+
+## 2.27.0
+
+#### Added
+
+- Support test target for local Swift Package #1074 @freddi-kit
+- Added `coverageTargets` for target test schemes. This enables to gather code coverage for specific targets. #1189 @gabriellanata
+- Fixed issue where .gyb files could not be added to source file list #1191 @hakkurishian
+
+### Fixed
+
+- Fixed crash caused by a simultaneous write during a glob processing #1177 @tr1ckyf0x
+- Skip generating empty compile sources build phases for watch apps #1185 @evandcoleman
+
 ## 2.26.0
 
 ### Added
 
-- Added the option to specify a `location` in a test target [#1150](https://github.com/yonaskolb/XcodeGen/issues/1150) @KrisRJack
+- Added the option to specify a `location` in a test target #1150 @KrisRJack
 
 ### Changed
 
-- Speed up source inclusion checking for big projects [#1122](https://github.com/yonaskolb/XcodeGen/pull/1122) @PaulTaykalo 
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.25.0...2.26.0)
+- Speed up source inclusion checking for big projects #1122 @PaulTaykalo 
 
 ## 2.25.0
 
 ### Added
-- Allow specifying a `copy` setting for each dependency. [#1038](https://github.com/yonaskolb/XcodeGen/pull/1039) @JakubBednar
+- Allow specifying a `copy` setting for each dependency. #1038 @JakubBednar
 
 ### Fixed
 
-- Fix broken codesign option for bundle dependency [#1104](https://github.com/yonaskolb/XcodeGen/pull/1104) @kateinoigakukun
-- Ensure fileTypes are mapped to JSON value [#1112](https://github.com/yonaskolb/XcodeGen/pull/1112) @namolnad
-- Fix platform filter for package dependecies [#1123](https://github.com/yonaskolb/XcodeGen/pull/1123) @raptorxcz
-- Fix Xcode 13 build [#1130](https://github.com/yonaskolb/XcodeGen/issues/1127) @raptorxcz @mthole
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.24.0...2.25.0)
+- Fix broken codesign option for bundle dependency #1104 @kateinoigakukun
+- Ensure fileTypes are mapped to JSON value #1112 @namolnad
+- Fix platform filter for package dependecies #1123 @raptorxcz
+- Fix Xcode 13 build #1130 @raptorxcz @mthole
 
 ### Changed
 
-- Update XcodeProj to 8.2.0 [#1125](https://github.com/yonaskolb/XcodeGen/pull/1125) @nnsnodnb
+- Update XcodeProj to 8.2.0 #1125 @nnsnodnb
 
 ## 2.24.0
 
 ### Added
 
-- Added support for DocC Catalogs [#1091](https://github.com/yonaskolb/XcodeGen/pull/1091) @brevansio
-- Added support for "driver-extension" and "system-extension" product types [#1092](https://github.com/yonaskolb/XcodeGen/issues/1092) @vgorloff
-- Add support for conditionally linking dependencies for specific platforms [#1087](https://github.com/yonaskolb/XcodeGen/pull/1087) @daltonclaybrook
-- Add ability to specify UI testing screenshot behavior in test schemes [#942](https://github.com/yonaskolb/XcodeGen/pull/942) @daltonclaybrook
+- Added support for DocC Catalogs #1091 @brevansio
+- Added support for "driver-extension" and "system-extension" product types #1092 @vgorloff
+- Add support for conditionally linking dependencies for specific platforms #1087 @daltonclaybrook
+- Add ability to specify UI testing screenshot behavior in test schemes #942 @daltonclaybrook
 
 ### Changed
-- **Breaking**: Rename the `platform` field on `Dependency` to `platformFilter` [#1087](https://github.com/yonaskolb/XcodeGen/pull/1087) @daltonclaybrook
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.23.1...2.24.0)
+- **Breaking**: Rename the `platform` field on `Dependency` to `platformFilter` #1087 @daltonclaybrook
 
 ## 2.23.1
 
 ### Changed
 - Reverted "Change FRAMEWORK_SEARCH_PATH for xcframeworks (#1015)", introduced in 2.20.0. XCFrameworks need to be
-  referenced directly in the project for Xcode's build system to extract the appropriate frameworks [#1081](https://github.com/yonaskolb/XcodeGen/pull/1081) @elliottwilliams
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.23.0...2.23.1)
+  referenced directly in the project for Xcode's build system to extract the appropriate frameworks #1081 @elliottwilliams
 
 ## 2.23.0
 
 #### Added
-- Added ability to set custom platform for dependency [#934](https://github.com/yonaskolb/XcodeGen/pull/934) @raptorxcz
+- Added ability to set custom platform for dependency #934 @raptorxcz
 
 #### Fixed
-- Added `()` to config variant trimming charater set to fix scheme config variant lookups for some configs like `Debug (Development)` that broke in 2.22.0 [#1078](https://github.com/yonaskolb/XcodeGen/pull/1078) @DavidWoohyunLee
-- Fixed Linux builds on Swift 5.4 [#1083](https://github.com/yonaskolb/XcodeGen/pull/1083) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.22.0...2.23.0)
+- Added `()` to config variant trimming charater set to fix scheme config variant lookups for some configs like `Debug (Development)` that broke in 2.22.0 #1078 @DavidWoohyunLee
+- Fixed Linux builds on Swift 5.4 #1083 @yonaskolb
 
 ## 2.22.0
 
 #### Added
-- Support `runPostActionsOnFailure` for running build post scripts on failing build [#1075](https://github.com/yonaskolb/XcodeGen/pull/1075) @freddi-kit
+- Support `runPostActionsOnFailure` for running build post scripts on failing build #1075 @freddi-kit
 
 #### Changed
-- Xcode no longer alerts to project changes after regeneration, due to internal workspace not regenerating if identical [#1072](https://github.com/yonaskolb/XcodeGen/pull/1072) @yonaskolb
+- Xcode no longer alerts to project changes after regeneration, due to internal workspace not regenerating if identical #1072 @yonaskolb
 
 #### Fixed
-- Fixed no such module `DOT` error when package is used as a dependency [#1067](https://github.com/yonaskolb/XcodeGen/pull/1067) @yanamura
-- Fixed scheme config variant lookups for some configs like `ProdDebug` and `Prod-Debug` that broke in 2.21.0 [#1070](https://github.com/yonaskolb/XcodeGen/pull/1070) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.21.0...2.22.0)
+- Fixed no such module `DOT` error when package is used as a dependency #1067 @yanamura
+- Fixed scheme config variant lookups for some configs like `ProdDebug` and `Prod-Debug` that broke in 2.21.0 #1070 @yonaskolb
 
 ## 2.21.0
 
 #### Added
-- Support weak link for Swift Package Dependency [#1064](https://github.com/yonaskolb/XcodeGen/pull/1064) @freddi-kit
+- Support weak link for Swift Package Dependency #1064 @freddi-kit
 
 #### Changed
-- Carthage frameworks are no longer embedded for "order-only" target dependencies. This avoid redundant embeds in situations where a target's sources _import_ a Carthage framework but do not have a binary dependency on it (like a test target which runs in a host app). [#1041](https://github.com/yonaskolb/XcodeGen/pull/1041) @elliottwilliams
+- Carthage frameworks are no longer embedded for "order-only" target dependencies. This avoid redundant embeds in situations where a target's sources _import_ a Carthage framework but do not have a binary dependency on it (like a test target which runs in a host app). #1041 @elliottwilliams
 
 #### Fixed
-- The `Core` target is renamed to avoid collisions with other packages. [#1057](https://github.com/yonaskolb/XcodeGen/pull/1057) @elliottwilliams
-- Lookup scheme config variants by whole words, fixing incorrect assignment in names that contain subtrings of each other (eg PreProd and Prod) [#976](https://github.com/yonaskolb/XcodeGen/pull/976) @stefanomondino
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.20.0...2.21.0)
+- The `Core` target is renamed to avoid collisions with other packages. #1057 @elliottwilliams
+- Lookup scheme config variants by whole words, fixing incorrect assignment in names that contain subtrings of each other (eg PreProd and Prod) #976 @stefanomondino
 
 ## 2.20.0
 
 #### Added
-- Allow specifying a `github` name like `JohnSundell/Ink` instead of a full `url` for Swift Packages [#1029](https://github.com/yonaskolb/XcodeGen/pull/1029) @yonaskolb
+- Allow specifying a `github` name like `JohnSundell/Ink` instead of a full `url` for Swift Packages #1029 @yonaskolb
 - Added explicity `LastUpgradeCheck` and `LastUpgradeVersion` override support so it's possible to override these properties without using the `project.xcodeVersion`. [1013](https://github.com/yonaskolb/XcodeGen/pull/1013) @Andre113
-- Added `macroExpansion` for `run` in `schemes` [#1036](https://github.com/yonaskolb/XcodeGen/pull/1036) @freddi-kit
-- Added `askForAppToLaunch` for `profile` in `schemes` [#1035](https://github.com/yonaskolb/XcodeGen/pull/1035) @freddi-kit
-- Added support for selectedTests in schemes `Test` configuration. [#913](https://github.com/yonaskolb/XcodeGen/pull/913) @ooodin
+- Added `macroExpansion` for `run` in `schemes` #1036 @freddi-kit
+- Added `askForAppToLaunch` for `profile` in `schemes` #1035 @freddi-kit
+- Added support for selectedTests in schemes `Test` configuration. #913 @ooodin
 
 #### Fixed
-- Fixed regression on `.storekit` configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio
-- Fixed framework search paths when using `.xcframework`s. [#1015](https://github.com/yonaskolb/XcodeGen/pull/1015) @FranzBusch
-- Fixed bug where schemes without a build target would crash instead of displaying an error [#1040](https://github.com/yonaskolb/XcodeGen/pull/1040) @dalemyers
-- Fixed files with names ending in **Info.plist** (such as **GoogleServices-Info.plist**) from being omitted from the Copy Resources build phase. Now, only the resolved info plist file for each specific target is omitted. [#1027](https://github.com/yonaskolb/XcodeGen/pull/1027) @liamnichols
+- Fixed regression on `.storekit` configuration files' default build phase. #1026 @jcolicchio
+- Fixed framework search paths when using `.xcframework`s. #1015 @FranzBusch
+- Fixed bug where schemes without a build target would crash instead of displaying an error #1040 @dalemyers
+- Fixed files with names ending in **Info.plist** (such as **GoogleServices-Info.plist**) from being omitted from the Copy Resources build phase. Now, only the resolved info plist file for each specific target is omitted. #1027 @liamnichols
 
 #### Internal
-- Build universal binaries for release. XcodeGen now runs natively on Apple Silicon. [#1024](https://github.com/yonaskolb/XcodeGen/pull/1024) @thii
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.19.0...2.20.0)
+- Build universal binaries for release. XcodeGen now runs natively on Apple Silicon. #1024 @thii
 
 ## 2.19.0
 
 #### Added
-- Added support for building and running on Linux platforms. Tested for compatibility with Swift 5.3+ and Ubuntu 18.04. [#988](https://github.com/yonaskolb/XcodeGen/pull/988) @elliottwilliams
-- Added `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
-- Added `storeKitConfiguration` to allow specifying StoreKit Configuration in Scheme and TargetScheme, supporting either xcodeproj or xcworkspace via `schemePathPrefix` option. [#964](https://github.com/yonaskolb/XcodeGen/pull/964) @jcolicchio
-- Added more detailed error message with method arguments. [#990](https://github.com/yonaskolb/XcodeGen/pull/990) @bannzai
-- Added `basedOnDependencyAnalysis` to Project Spec Build Script to be able to choose not to skip the script. [#992](https://github.com/yonaskolb/XcodeGen/pull/992) @myihsan
-- Added `BuildRule.runOncePerArchitecture` to allow running build rules once per architecture. [#950](https://github.com/yonaskolb/XcodeGen/pull/950) @sascha
-- Added discovered dependency file for a build script [#1012](https://github.com/yonaskolb/XcodeGen/pull/1012) @polac24 @fggeraissate
+- Added support for building and running on Linux platforms. Tested for compatibility with Swift 5.3+ and Ubuntu 18.04. #988 @elliottwilliams
+- Added `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. #961 @liamnichols
+- Added `storeKitConfiguration` to allow specifying StoreKit Configuration in Scheme and TargetScheme, supporting either xcodeproj or xcworkspace via `schemePathPrefix` option. #964 @jcolicchio
+- Added more detailed error message with method arguments. #990 @bannzai
+- Added `basedOnDependencyAnalysis` to Project Spec Build Script to be able to choose not to skip the script. #992 @myihsan
+- Added `BuildRule.runOncePerArchitecture` to allow running build rules once per architecture. #950 @sascha
+- Added discovered dependency file for a build script #1012 @polac24 @fggeraissate
 
 #### Changed
-- **Breaking**: Info.plists with custom prefixes are no longer added to the Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
-- **Breaking**: `workingDirectory` of included legacy targets is now made relative to including project [#981](https://github.com/yonaskolb/XcodeGen/pull/981) @jcolicchio
-- **Breaking**: Make `simulateLocation` respect `schemePathPrefix` option. [#973](https://github.com/yonaskolb/XcodeGen/pull/973) @jcolicchio
+- **Breaking**: Info.plists with custom prefixes are no longer added to the Copy Bundle Resources build phase #945 @anivaros
+- **Breaking**: `workingDirectory` of included legacy targets is now made relative to including project #981 @jcolicchio
+- **Breaking**: Make `simulateLocation` respect `schemePathPrefix` option. #973 @jcolicchio
 
 #### Fixed
-- Fixed error message output for `minimumXcodeGenVersion`. [#967](https://github.com/yonaskolb/XcodeGen/pull/967) @joshwalker
-- Remove force-unwrapping causing crash for `LegacyTarget`s [#982](https://github.com/yonaskolb/XcodeGen/pull/982) @jcolicchio
-- Fixed a race condition in an internal JSON decoder, which would occasionally fail with an error like `Parsing project spec failed: Error Domain=Unspecified error Code=0`. [#995](https://github.com/yonaskolb/XcodeGen/pull/995) @elliottwilliams
-- Fixed issue where frameworks with `MACH_O_TYPE: staticlib` were being incorrectly embedded. [#1003](https://github.com/yonaskolb/XcodeGen/pull/1003) @mrabiciu
+- Fixed error message output for `minimumXcodeGenVersion`. #967 @joshwalker
+- Remove force-unwrapping causing crash for `LegacyTarget`s #982 @jcolicchio
+- Fixed a race condition in an internal JSON decoder, which would occasionally fail with an error like `Parsing project spec failed: Error Domain=Unspecified error Code=0`. #995 @elliottwilliams
+- Fixed issue where frameworks with `MACH_O_TYPE: staticlib` were being incorrectly embedded. #1003 @mrabiciu
 
 #### Internal
-- Updated to Yams 4.0.0 [#984](https://github.com/yonaskolb/XcodeGen/pull/984) @swiftty
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.18.0...2.19.0)
+- Updated to Yams 4.0.0 #984 @swiftty
 
 ## 2.18.0
 
 #### Added
-- Add `Scheme.Test.TestTarget.skipped` to allow skipping of an entire test target. [#916](https://github.com/yonaskolb/XcodeGen/pull/916) @codeman9
-- Added ability to set custom LLDBInit scripts for launch and test schemes [#929](https://github.com/yonaskolb/XcodeGen/pull/929) @polac24
-- Adds App Clip support. [#909](https://github.com/yonaskolb/XcodeGen/pull/909) @brentleyjones @dflems
-- Application extension schemes now default to `launchAutomaticallySubstyle = 2` and the correct debugger and launcher identifiers [#932](https://github.com/yonaskolb/XcodeGen/pull/932) @brentleyjones
-- Updated SettingsPresets to use new defaults from Xcode 12. [#953](https://github.com/yonaskolb/XcodeGen/pull/953) @liamnichols
-- Enable Base Internationalization by default as per Xcode 12 behavior. [#954](https://github.com/yonaskolb/XcodeGen/issues/954) @liamnichols
+- Add `Scheme.Test.TestTarget.skipped` to allow skipping of an entire test target. #916 @codeman9
+- Added ability to set custom LLDBInit scripts for launch and test schemes #929 @polac24
+- Adds App Clip support. #909 @brentleyjones @dflems
+- Application extension schemes now default to `launchAutomaticallySubstyle = 2` and the correct debugger and launcher identifiers #932 @brentleyjones
+- Updated SettingsPresets to use new defaults from Xcode 12. #953 @liamnichols
+- Enable Base Internationalization by default as per Xcode 12 behavior. #954 @liamnichols
 
 #### Changed
-- Change default project version to Xcode 12 [#960](https://github.com/yonaskolb/XcodeGen/pull/960) @yonaskolb
+- Change default project version to Xcode 12 #960 @yonaskolb
 
 #### Internal
-- Updates CI to run on Xcode 12. [#936](https://github.com/yonaskolb/XcodeGen/pull/936) [#960](https://github.com/yonaskolb/XcodeGen/pull/960) @dflems @yonaskolb
+- Updates CI to run on Xcode 12. #936 @dflems @yonaskolb
 
 #### Fixed
-- Select the first runnable build target, if present. [#957](https://github.com/yonaskolb/XcodeGen/pull/957) @codeman9
-- Allow SDK dependencies to be embedded. [#922](https://github.com/yonaskolb/XcodeGen/pull/922) @k-thorat
-- Allow creating intermediary groups outside of the project directory. [#892](https://github.com/yonaskolb/XcodeGen/pull/892) @segiddins
-- Fix appex's Runpath Search Paths under macOS target. [#952](https://github.com/yonaskolb/XcodeGen/pull/952) @rinsuki
-- `onlyCopyFilesOnInstall` is extended for the Embed App Extensions build phase. [#948](https://github.com/yonaskolb/XcodeGen/pull/948) @RomanPodymov
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.17.0...2.18.0)
+- Select the first runnable build target, if present. #957 @codeman9
+- Allow SDK dependencies to be embedded. #922 @k-thorat
+- Allow creating intermediary groups outside of the project directory. #892 @segiddins
+- Fix appex's Runpath Search Paths under macOS target. #952 @rinsuki
+- `onlyCopyFilesOnInstall` is extended for the Embed App Extensions build phase. #948 @RomanPodymov
 
 ## 2.17.0
 
 #### Added
-- Added `options.fileTypes` which lets you set cross project defaults for certain file extensions [#914](https://github.com/yonaskolb/XcodeGen/pull/914) @yonaskolb
-- Added `onlyCopyFilesOnInstall` option to targets for the Embed Files build phase. [#912](https://github.com/yonaskolb/XcodeGen/pull/912) @jsorge
+- Added `options.fileTypes` which lets you set cross project defaults for certain file extensions #914 @yonaskolb
+- Added `onlyCopyFilesOnInstall` option to targets for the Embed Files build phase. #912 @jsorge
 
 #### Fixed
-- Treat all directories with known UTI as file wrapper. [#896](https://github.com/yonaskolb/XcodeGen/pull/896) @KhaosT
-- Generated schemes for application extensions now contain `wasCreatedForAppExtension = YES`. [#898](https://github.com/yonaskolb/XcodeGen/issues/898) @muizidn
-- Allow package dependencies to use `link: false` [#920](https://github.com/yonaskolb/XcodeGen/pull/920) @k-thorat
-- Fixed issue computing relative paths.  [#915](https://github.com/yonaskolb/XcodeGen/pull/915) @andrewreach
+- Treat all directories with known UTI as file wrapper. #896 @KhaosT
+- Generated schemes for application extensions now contain `wasCreatedForAppExtension = YES`. #898 @muizidn
+- Allow package dependencies to use `link: false` #920 @k-thorat
+- Fixed issue computing relative paths.  #915 @andrewreach
 
 #### Internal
-- Updated to XcodeProj 7.13.0 [#908](https://github.com/yonaskolb/XcodeGen/pull/908) @brentleyjones
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.16.0...2.17.0)
+- Updated to XcodeProj 7.13.0 #908 @brentleyjones
 
 ## 2.16.0
 
 #### Added
-- Improve speed of metadata parsing and dependency resolution. [#803](https://github.com/yonaskolb/XcodeGen/pull/803) @michaeleisel
-- Improve support for iOS sticker packs and add support for `launchAutomaticallySubstyle` to run schemes. [#824](https://github.com/yonaskolb/XcodeGen/pull/824) @scelis
-- Add --project-root option to generate command. [#828](https://github.com/yonaskolb/XcodeGen/pull/828) @ileitch
-- Add an ability to set an order of groups with `options.groupOrdering` [#613](https://github.com/yonaskolb/XcodeGen/pull/613) @Beniamiiin
-- Add the ability to output a dependency graph in graphviz format [#852](https://github.com/yonaskolb/XcodeGen/pull/852) @jeffctown
-- Adds uncluttering the project manifest dumped to YAML from empty values [#858](https://github.com/yonaskolb/XcodeGen/pull/858) @paciej00
-- Added ability to name the executable target when declaring schemes. [#869](https://github.com/yonaskolb/XcodeGen/pull/869) @elland
-- Added ability to set executable to Ask to Launch. [#871](https://github.com/yonaskolb/XcodeGen/pull/871) @pinda
+- Improve speed of metadata parsing and dependency resolution. #803 @michaeleisel
+- Improve support for iOS sticker packs and add support for `launchAutomaticallySubstyle` to run schemes. #824 @scelis
+- Add --project-root option to generate command. #828 @ileitch
+- Add an ability to set an order of groups with `options.groupOrdering` #613 @Beniamiiin
+- Add the ability to output a dependency graph in graphviz format #852 @jeffctown
+- Adds uncluttering the project manifest dumped to YAML from empty values #858 @paciej00
+- Added ability to name the executable target when declaring schemes. #869 @elland
+- Added ability to set executable to Ask to Launch. #871 @pinda
 
 #### Fixed
-- Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia
-- Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826) @asifmohd
-- Prefix static library target filenames with 'lib' to match Xcode. [#831](https://github.com/yonaskolb/XcodeGen/pull/831), [#842](https://github.com/yonaskolb/XcodeGen/pull/842) @ileitch
-- Fixed duplicate addition of carthage static frameworks. [#829](https://github.com/yonaskolb/XcodeGen/pull/829) @funzin
-- Fix handling of SWIFT_INSTALL_OBJC_HEADER when its value is YES/NO. [#827](https://github.com/yonaskolb/XcodeGen/pull/827) @ileitch
-- Set `preActions` and `postActions` on the `build` action of a TargetScheme instead of the other actions. [#823](https://github.com/yonaskolb/XcodeGen/pull/823) @brentleyjones
-- Prevent test targets from being set as a scheme's launch action [#835](https://github.com/yonaskolb/XcodeGen/pull/835) @brentleyjones
-- Implicitly include bundles in the Copy Bundle Resources build phase. [#838](https://github.com/yonaskolb/XcodeGen/pull/838) @skirchmeier
-- Fixed dumping a project manifest which contains an array of project references [#840](https://github.com/yonaskolb/XcodeGen/pull/840) @paciej00
-- Generate correct PBXTargetDependency for external targets. [#843](https://github.com/yonaskolb/XcodeGen/pull/843) @ileitch
-- Fix linking of multiple products from the same Swift Package [#830](https://github.com/yonaskolb/XcodeGen/pull/830) @toshi0383
-- Don't deduplicate files in `include` with different path but same name. [#849](https://github.com/yonaskolb/XcodeGen/pull/849) @akkyie
-- Don't link transitive static carthage libraries. [#853](https://github.com/yonaskolb/XcodeGen/pull/853) @akkyie
-- Optimize simplifying paths for faster project generation. [#857](https://github.com/yonaskolb/XcodeGen/pull/857) @akkyie
-- Fixed issue where wrapper folders may not include correctly in the generated project. [#862](https://github.com/yonaskolb/XcodeGen/pull/862) @KhaosT
-- Compile `xcmappingmodel` files instead of copying bundle resources. [#834](https://github.com/yonaskolb/XcodeGen/pull/834) @jcolicchio
-- Fixed issue where `Complie Sources` build phase is generated for resource bundles even when they have no files to compile [#878](https://github.com/yonaskolb/XcodeGen/pull/878) @nkukushkin
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.15.1...2.16.0)
+- Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. #820 @acecilia
+- Fixed issue when generating projects for paths with a dot in the folder for swift sources. #826 @asifmohd
+- Prefix static library target filenames with 'lib' to match Xcode. #831 @ileitch
+- Fixed duplicate addition of carthage static frameworks. #829 @funzin
+- Fix handling of SWIFT_INSTALL_OBJC_HEADER when its value is YES/NO. #827 @ileitch
+- Set `preActions` and `postActions` on the `build` action of a TargetScheme instead of the other actions. #823 @brentleyjones
+- Prevent test targets from being set as a scheme's launch action #835 @brentleyjones
+- Implicitly include bundles in the Copy Bundle Resources build phase. #838 @skirchmeier
+- Fixed dumping a project manifest which contains an array of project references #840 @paciej00
+- Generate correct PBXTargetDependency for external targets. #843 @ileitch
+- Fix linking of multiple products from the same Swift Package #830 @toshi0383
+- Don't deduplicate files in `include` with different path but same name. #849 @akkyie
+- Don't link transitive static carthage libraries. #853 @akkyie
+- Optimize simplifying paths for faster project generation. #857 @akkyie
+- Fixed issue where wrapper folders may not include correctly in the generated project. #862 @KhaosT
+- Compile `xcmappingmodel` files instead of copying bundle resources. #834 @jcolicchio
+- Fixed issue where `Complie Sources` build phase is generated for resource bundles even when they have no files to compile #878 @nkukushkin
 
 ## 2.15.1
 
 #### Fixed
-- Fixed issue which caused watch app schemes to be generated incorrectly, preventing these apps from launching. [#798](https://github.com/yonaskolb/XcodeGen/pull/798) @daltonclaybrook
-- Added build presets for the target type `framework.static`. [#819](https://github.com/yonaskolb/XcodeGen/pull/819) @acecilia
-- Fixed XcodeProj resolution and updated to 7.10.0 [#822](https://github.com/yonaskolb/XcodeGen/pull/822) @soffes
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.15.0...2.15.1)
+- Fixed issue which caused watch app schemes to be generated incorrectly, preventing these apps from launching. #798 @daltonclaybrook
+- Added build presets for the target type `framework.static`. #819 @acecilia
+- Fixed XcodeProj resolution and updated to 7.10.0 #822 @soffes
 
 ## 2.15.0
 
 #### Added
-- Add support for local Swift Packages in `packages` using `path`. [#808](https://github.com/yonaskolb/XcodeGen/pull/808) @freddi-kit
-- Add `buildImplicitDependencies` as an option on `TargetScheme`. [#810](https://github.com/yonaskolb/XcodeGen/pull/810) @evandcoleman
+- Add support for local Swift Packages in `packages` using `path`. #808 @freddi-kit
+- Add `buildImplicitDependencies` as an option on `TargetScheme`. #810 @evandcoleman
 
 #### Fixed
-- Fixed resolving path to local Swift Packages [#796](https://github.com/yonaskolb/XcodeGen/pull/796) @freddi-kit
-- Added ability to stop on every main thread checker issue on Run schemes and TargetSchemes [#799](https://github.com/yonaskolb/XcodeGen/pull/799) @ionutivan
-- Avoid copying ObjC interface header when SWIFT_INSTALL_OBJC_HEADER=false. [#805](https://github.com/yonaskolb/XcodeGen/pull/805) @kateinoigakukun
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.14.0...2.15.0)
+- Fixed resolving path to local Swift Packages #796 @freddi-kit
+- Added ability to stop on every main thread checker issue on Run schemes and TargetSchemes #799 @ionutivan
+- Avoid copying ObjC interface header when SWIFT_INSTALL_OBJC_HEADER=false. #805 @kateinoigakukun
 
 ## 2.14.0
 
 #### Added
-- Add ability to embed and code sign Swift package dependencies with dynamic products. [#788](https://github.com/yonaskolb/XcodeGen/pull/788) @alexruperez
+- Add ability to embed and code sign Swift package dependencies with dynamic products. #788 @alexruperez
 
 #### Fixed
-- Revert "Add Base to known regions even if one doesn't exist" [#791](https://github.com/yonaskolb/XcodeGen/pull/792) @bryansum
-- Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787) @ken0nek
-- Set `TEST_TARGET_NAME` only when a project has UITest bundle. [#792](https://github.com/yonaskolb/XcodeGen/pull/792) @ken0nek
-- Set xcodeproj path in project.xcworkspace/contents.xcworkspacedata [#793](https://github.com/yonaskolb/XcodeGen/pull/793) @ken0nek
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.13.1...2.14.0)
+- Revert "Add Base to known regions even if one doesn't exist" #791 @bryansum
+- Set `defaultConfigurationName` for every target which is defined in a project. #787 @ken0nek
+- Set `TEST_TARGET_NAME` only when a project has UITest bundle. #792 @ken0nek
+- Set xcodeproj path in project.xcworkspace/contents.xcworkspacedata #793 @ken0nek
 
 ## 2.13.1
 
 #### Fixed
-- Validate scheme test action and test coverage target references before generating. [#775](https://github.com/yonaskolb/XcodeGen/pull/775) @liamnichols
-- Fixed parsing prerelease identifiers in Swift package versions [#779](https://github.com/yonaskolb/XcodeGen/pull/779) @yonaskolb
-- Fixed using legacy targets as dependencies [#778](https://github.com/yonaskolb/XcodeGen/pull/778) @yonaskolb
+- Validate scheme test action and test coverage target references before generating. #775 @liamnichols
+- Fixed parsing prerelease identifiers in Swift package versions #779 @yonaskolb
+- Fixed using legacy targets as dependencies #778 @yonaskolb
 
 #### Internal
-- Updated to XcodeProj 7.8.0 [#777](https://github.com/yonaskolb/XcodeGen/pull/777) @yonaskolb
-- Use https://github.com/mxcl/Version [#779](https://github.com/yonaskolb/XcodeGen/pull/779) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.13.0...2.13.1)
+- Updated to XcodeProj 7.8.0 #777 @yonaskolb
+- Use https://github.com/mxcl/Version #779 @yonaskolb
 
 ## 2.13.0
 
 #### Added
-- Support External Target References via subprojects. [#701](https://github.com/yonaskolb/XcodeGen/pull/701) @evandcoleman
+- Support External Target References via subprojects. #701 @evandcoleman
 
 #### Fixed
-- Fixed compilation as library by locking down XcodeProj version [#767](https://github.com/yonaskolb/XcodeGen/pull/767) @yonaskolb
-- Stabilized sorting of groups with duplicate names/paths. [#671](https://github.com/yonaskolb/XcodeGen/pull/671) @ChristopherRogers
-- Moved `Copy Bundle Resources` to after `Link with Libraries` build phase [#768](https://github.com/yonaskolb/XcodeGen/pull/768) @yonaskolb
+- Fixed compilation as library by locking down XcodeProj version #767 @yonaskolb
+- Stabilized sorting of groups with duplicate names/paths. #671 @ChristopherRogers
+- Moved `Copy Bundle Resources` to after `Link with Libraries` build phase #768 @yonaskolb
 
 #### Internal
-- Updated to XcodeProj 7.7.0 [#767](https://github.com/yonaskolb/XcodeGen/pull/767) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.12.0...2.13.0)
+- Updated to XcodeProj 7.7.0 #767 @yonaskolb
 
 ## 2.12.0
 
 #### Added
-- Added pre and post command options. Useful for running `pod install` in combination with `--use-cache` [#759](https://github.com/yonaskolb/XcodeGen/pull/759) @yonaskolb
-- Support for language and region settings on a target basis [#728](https://github.com/yonaskolb/XcodeGen/pull/728) @FranzBusch
-- Added option to generate only Info.plist files with `--only-plists` [#739](https://github.com/yonaskolb/XcodeGen/pull/739) @namolnad
-- Added the option to specify a `simulateLocation` in a scheme [#722](https://github.com/yonaskolb/XcodeGen/issues/722) @basvankuijck
-- Support for On Demand Resources tags [#753](https://github.com/yonaskolb/XcodeGen/pull/753) @sipao
+- Added pre and post command options. Useful for running `pod install` in combination with `--use-cache` #759 @yonaskolb
+- Support for language and region settings on a target basis #728 @FranzBusch
+- Added option to generate only Info.plist files with `--only-plists` #739 @namolnad
+- Added the option to specify a `simulateLocation` in a scheme #722 @basvankuijck
+- Support for On Demand Resources tags #753 @sipao
 
 #### Fixed
-- Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun
-- Don't add framework dependency's directory to `FRAMEWORK_SEARCH_PATHS` if it is implicit [#744](https://github.com/yonaskolb/XcodeGen/pull/744) @ikesyo @yutailang0119
-- Fixed resolving relative path passed to `XcodeProj` [#751](https://github.com/yonaskolb/XcodeGen/pull/751) @PycKamil
-- Prefer configurations named "Debug" or "Release" for default scheme build configurations [#752](https://github.com/yonaskolb/XcodeGen/pull/752) @john-flanagan
-- Added an extra check for package versions. [#755](https://github.com/yonaskolb/XcodeGen/pull/755) @basvankuijck
+- Fixed resolving a relative path for `projectReference.path` #740 @kateinoigakukun
+- Don't add framework dependency's directory to `FRAMEWORK_SEARCH_PATHS` if it is implicit #744 @ikesyo @yutailang0119
+- Fixed resolving relative path passed to `XcodeProj` #751 @PycKamil
+- Prefer configurations named "Debug" or "Release" for default scheme build configurations #752 @john-flanagan
+- Added an extra check for package versions. #755 @basvankuijck
 
 #### Internal
-- Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.11.0...2.12.0)
+- Update to SwiftCLI 6.0 and use the new property wrappers #749 @yonaskolb
 
 ## 2.11.0
 
 #### Added
-- Add Carthage static framework dependencies support. [#688](https://github.com/yonaskolb/XcodeGen/pull/688) @giginet
-- Added `xcodegen dump` command [#710](https://github.com/yonaskolb/XcodeGen/pull/710) @yonaskolb
-- Added `--no-env` option to disable environment variables expansion [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
-- Added custom group support for target sources [#621](https://github.com/yonaskolb/XcodeGen/pull/621) @sroebert @rcari
-- Added new dependency type, `bundle`. This allows targets to copy bundles from other projects [#616](https://github.com/yonaskolb/XcodeGen/pull/616) @bsmith11
+- Add Carthage static framework dependencies support. #688 @giginet
+- Added `xcodegen dump` command #710 @yonaskolb
+- Added `--no-env` option to disable environment variables expansion #704 @rcari
+- Added custom group support for target sources #621 @sroebert @rcari
+- Added new dependency type, `bundle`. This allows targets to copy bundles from other projects #616 @bsmith11
 
 #### Fixed
-- Improved variable expansion runtime [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
-- Fixed missing headers for static framework targets [#705](https://github.com/yonaskolb/XcodeGen/pull/705) @wag-miles
-- Using more file types from XcodeProj for PBXFileReferences resulting in less project diffs [#715](https://github.com/yonaskolb/XcodeGen/pull/715) @yonaskolb
-- Fixed localized `*.intentdefinition` not being added to build source phases [#720](https://github.com/yonaskolb/XcodeGen/pull/720) @giginet
-- Fixed `selectedLauncherIdentifier` not being set `Xcode.IDEFoundation.Launcher.PosixSpawn` when `debugEnabled: false` is defined in test action [#725](https://github.com/yonaskolb/XcodeGen/pull/725) @ken0nek
-- Fixed unnecessary dependencies related to SwiftPM [#726](https://github.com/yonaskolb/XcodeGen/pull/726) @tid-kijyun
+- Improved variable expansion runtime #704 @rcari
+- Fixed missing headers for static framework targets #705 @wag-miles
+- Using more file types from XcodeProj for PBXFileReferences resulting in less project diffs #715 @yonaskolb
+- Fixed localized `*.intentdefinition` not being added to build source phases #720 @giginet
+- Fixed `selectedLauncherIdentifier` not being set `Xcode.IDEFoundation.Launcher.PosixSpawn` when `debugEnabled: false` is defined in test action #725 @ken0nek
+- Fixed unnecessary dependencies related to SwiftPM #726 @tid-kijyun
 
 #### Changed
-- Deprecated `$old_form` variables in favor of `${new_form}` variables [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
-- Updated XcodeProj to 7.4.0 [#709](https://github.com/yonaskolb/XcodeGen/pull/709) [#715](https://github.com/yonaskolb/XcodeGen/pull/715) @yonaskolb
-- Updated to Swift 5.1 [#714](https://github.com/yonaskolb/XcodeGen/pull/714) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.10.1...2.11.0)
+- Deprecated `$old_form` variables in favor of `${new_form}` variables #704 @rcari
+- Updated XcodeProj to 7.4.0 #709 @yonaskolb
+- Updated to Swift 5.1 #714 @yonaskolb
 
 ## 2.10.1
 
 #### Fixed
-- Add Base to knownRegions even if one doesn't exist [#694](https://github.com/yonaskolb/XcodeGen/pull/694) @bryansum
-- Fixed missing `onlyGenerateCoverageForSpecifiedTargets` issue [#700](https://github.com/yonaskolb/XcodeGen/pull/700) @kateinoigakukun
-- Fixed regression on dependencies `link` flag [#703](https://github.com/yonaskolb/XcodeGen/pull/703) @rcari
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.10.0...2.10.1)
+- Add Base to knownRegions even if one doesn't exist #694 @bryansum
+- Fixed missing `onlyGenerateCoverageForSpecifiedTargets` issue #700 @kateinoigakukun
+- Fixed regression on dependencies `link` flag #703 @rcari
 
 ## 2.10.0
 
 #### Added
-- Support Target Reference to another project. [#655](https://github.com/yonaskolb/XcodeGen/pull/655) @kateinoigakukun
-- Added `coverageTargets` for test target. This enables to gather code coverage for specific targets. [#656](https://github.com/yonaskolb/XcodeGen/pull/656) @kateinoigakukun
+- Support Target Reference to another project. #655 @kateinoigakukun
+- Added `coverageTargets` for test target. This enables to gather code coverage for specific targets. #656 @kateinoigakukun
 
 #### Fixed
-- Add base localisation by default even if no base localised files were found. Fixes warning in Xcode 11 [#685](https://github.com/yonaskolb/XcodeGen/pull/685) @yonaskolb
-- Don't generate CFBundleExecutable in default generated Info.plist for `bundle` target types [#689](https://github.com/yonaskolb/XcodeGen/pull/689) @FranzBusch
-- Fixed resolving relative paths with custom project destination [#681](https://github.com/yonaskolb/XcodeGen/pull/681) @giginet
-- Fixed resolving relative paths for Info.plist [#683](https://github.com/yonaskolb/XcodeGen/pull/683) @giginet
-- Fixed macOS unit test target TEST_HOST [#696](https://github.com/yonaskolb/XcodeGen/pull/696) @mjarvis
+- Add base localisation by default even if no base localised files were found. Fixes warning in Xcode 11 #685 @yonaskolb
+- Don't generate CFBundleExecutable in default generated Info.plist for `bundle` target types #689 @FranzBusch
+- Fixed resolving relative paths with custom project destination #681 @giginet
+- Fixed resolving relative paths for Info.plist #683 @giginet
+- Fixed macOS unit test target TEST_HOST #696 @mjarvis
 
 #### Internal
-- Restructure targets [#698](https://github.com/yonaskolb/XcodeGen/pull/698) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.9.0...2.10.0)
+- Restructure targets #698 @yonaskolb
 
 ## 2.9.0
 
 #### Added
-- Added Scheme Templates [#672](https://github.com/yonaskolb/XcodeGen/pull/672) @bclymer
+- Added Scheme Templates #672 @bclymer
 
 #### Fixed
-- Fixed macOS unit test setting preset [#665](https://github.com/yonaskolb/XcodeGen/pull/665) @yonaskolb
-- Add `rcproject` files to sources build phase instead of resources [#669](https://github.com/yonaskolb/XcodeGen/pull/669) @Qusic
-- Prefer default configuration names for generated schemes [#673](https://github.com/yonaskolb/XcodeGen/pull/673) @giginet
-- Fixed some resource files being placed to "Recovered References" group [#679](https://github.com/yonaskolb/XcodeGen/pull/679) @nivanchikov
+- Fixed macOS unit test setting preset #665 @yonaskolb
+- Add `rcproject` files to sources build phase instead of resources #669 @Qusic
+- Prefer default configuration names for generated schemes #673 @giginet
+- Fixed some resource files being placed to "Recovered References" group #679 @nivanchikov
 
 #### Internal
-- Updated to SwiftCLI 5.3.2 [#667](https://github.com/yonaskolb/XcodeGen/pull/667) @giginet
-- Fixed tests in case-sensitive file system [#670](https://github.com/yonaskolb/XcodeGen/pull/670) @Qusic
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.8.0...2.9.0)
+- Updated to SwiftCLI 5.3.2 #667 @giginet
+- Fixed tests in case-sensitive file system #670 @Qusic
 
 ## 2.8.0
 
 #### Added
-- Added support for Swift Package dependencies [#624](https://github.com/yonaskolb/XcodeGen/pull/624) @yonaskolb
-- Added `includes` to `sources` for a Target. This follows the same glob-style as `excludes` but functions as a way to only include files that match a specified pattern. Useful if you only want a certain file type, for example specifying `**/*.swift`. [#637](https://github.com/yonaskolb/XcodeGen/pull/637) @bclymer
-- Support `dylib` SDK. [#650](https://github.com/yonaskolb/XcodeGen/pull/650) @kateinoigakukun
-- Added `language` and `region` options for `run` and `test` scheme [#654](https://github.com/yonaskolb/XcodeGen/pull/654) @kateinoigakukun
-- Added `debugEnabled` option for `run` and `test` scheme [#657](https://github.com/yonaskolb/XcodeGen/pull/657) @kateinoigakukun
+- Added support for Swift Package dependencies #624 @yonaskolb
+- Added `includes` to `sources` for a Target. This follows the same glob-style as `excludes` but functions as a way to only include files that match a specified pattern. Useful if you only want a certain file type, for example specifying `**/*.swift`. #637 @bclymer
+- Support `dylib` SDK. #650 @kateinoigakukun
+- Added `language` and `region` options for `run` and `test` scheme #654 @kateinoigakukun
+- Added `debugEnabled` option for `run` and `test` scheme #657 @kateinoigakukun
 
 #### Fixed
-- Expand template variable in Array of Any [#651](https://github.com/yonaskolb/XcodeGen/pull/651) @kateinoigakukun
-- Significantly improve performance when running with a large number files. [#658](https://github.com/yonaskolb/XcodeGen/pull/658) @kateinoigakukun
-- Removed some more diffs between the generated .pbxproj and when Xcode resaves it [#663](https://github.com/yonaskolb/XcodeGen/pull/663) @yonaskolb
+- Expand template variable in Array of Any #651 @kateinoigakukun
+- Significantly improve performance when running with a large number files. #658 @kateinoigakukun
+- Removed some more diffs between the generated .pbxproj and when Xcode resaves it #663 @yonaskolb
 
 #### Internal
-- Removed needless `Array` initialization. [#661](https://github.com/yonaskolb/XcodeGen/pull/661) @RomanPodymov
-- Updated to XcodeProj 7.1.0 [#624](https://github.com/yonaskolb/XcodeGen/pull/624) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.7.0...2.8.0)
+- Removed needless `Array` initialization. #661 @RomanPodymov
+- Updated to XcodeProj 7.1.0 #624 @yonaskolb
 
 ## 2.7.0
 
 #### Added
-- Added Bash 4 style recursive globbing (`**/*`) in target sources `excludes` [#636](https://github.com/yonaskolb/XcodeGen/pull/636) @bclymer
-- Added ability to disable main thread checker in Schemes [#601](https://github.com/yonaskolb/XcodeGen/pull/601) @wag-miles
+- Added Bash 4 style recursive globbing (`**/*`) in target sources `excludes` #636 @bclymer
+- Added ability to disable main thread checker in Schemes #601 @wag-miles
 
 #### Fixed
-- Fixed included specs that were referenced multiple times from duplicating content [#599](https://github.com/yonaskolb/XcodeGen/pull/599) @haritowa
-- Fixed `.orig` files being added to the project [#627](https://github.com/yonaskolb/XcodeGen/pull/627) @keith
+- Fixed included specs that were referenced multiple times from duplicating content #599 @haritowa
+- Fixed `.orig` files being added to the project #627 @keith
 
 #### Changed
-- Allow linking of dependencies into static libraries when `link` is set to true [#635](https://github.com/yonaskolb/XcodeGen/pull/635) @kateinoigakukun
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.6.0...2.7.0)
+- Allow linking of dependencies into static libraries when `link` is set to true #635 @kateinoigakukun
 
 ## 2.6.0
 
 #### Added
-- Added ability to skip tests [#582](https://github.com/yonaskolb/XcodeGen/pull/582) @kadarandras
-- Added ability to set `attributes` on build files [#583](https://github.com/yonaskolb/XcodeGen/pull/583) @min
-- Allow using environment variables in the form of `${SOME_VARIABLE}`. This might be a **breaking** change when a target template attribute is also defined as an environment variable [#594](https://github.com/yonaskolb/XcodeGen/pull/594) @tomquist
-- Added support for `watchapp2-container` and `framework.static` product types [#604](https://github.com/yonaskolb/XcodeGen/pull/604) @yonaskolb
+- Added ability to skip tests #582 @kadarandras
+- Added ability to set `attributes` on build files #583 @min
+- Allow using environment variables in the form of `${SOME_VARIABLE}`. This might be a **breaking** change when a target template attribute is also defined as an environment variable #594 @tomquist
+- Added support for `watchapp2-container` and `framework.static` product types #604 @yonaskolb
 
 #### Fixed
-- Fixed `.pch` files being bundled as resources [#597](https://github.com/yonaskolb/XcodeGen/pull/597) @thii
-- Fixed an issue that prevents watchOS Intents Extension from running correctly. [#571](https://github.com/yonaskolb/XcodeGen/pull/571) @KhaosT
+- Fixed `.pch` files being bundled as resources #597 @thii
+- Fixed an issue that prevents watchOS Intents Extension from running correctly. #571 @KhaosT
 
 #### Changed
-- Updated the default `compatibilityVersion` project setting from `Xcode 9.3` to `Xcode 10.0` [#581](https://github.com/yonaskolb/XcodeGen/pull/581) @acecilia
-- Updated to XcodeProj 7.0.0. Note that the length of generated UUIDs has changed [#604](https://github.com/yonaskolb/XcodeGen/pull/604) @yonaskolb
+- Updated the default `compatibilityVersion` project setting from `Xcode 9.3` to `Xcode 10.0` #581 @acecilia
+- Updated to XcodeProj 7.0.0. Note that the length of generated UUIDs has changed #604 @yonaskolb
 
 #### Internal
-- Added ability to encode ProjectSpec [#545](https://github.com/yonaskolb/XcodeGen/pull/545) @ryohey
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.5.0...2.6.0)
+- Added ability to encode ProjectSpec #545 @ryohey
 
 ## 2.5.0
 
 #### Added
-- Added support for `app-extension.intents-service` target type [#536](https://github.com/yonaskolb/XcodeGen/pull/536) @yonaskolb
-- Added support for custom `root` in `sdk` dependency [#562](https://github.com/yonaskolb/XcodeGen/pull/562) @raptorxcz
+- Added support for `app-extension.intents-service` target type #536 @yonaskolb
+- Added support for custom `root` in `sdk` dependency #562 @raptorxcz
 
 #### Changed
-- Updated to xcodeproj 6.7.0 including its performance improvements [#536](https://github.com/yonaskolb/XcodeGen/pull/536) @yonaskolb
-- Updated default generated settings for Xcode 10.2 [#555](https://github.com/yonaskolb/XcodeGen/pull/555) @yonaskolb
-- Changed order of file generation so that plists are now generated before the project, so they will be included in the projects files [#544](https://github.com/yonaskolb/XcodeGen/issues/544) @tomquist
+- Updated to xcodeproj 6.7.0 including its performance improvements #536 @yonaskolb
+- Updated default generated settings for Xcode 10.2 #555 @yonaskolb
+- Changed order of file generation so that plists are now generated before the project, so they will be included in the projects files #544 @tomquist
 - Updated Yams to 2.0.0 @yonaskolb
 
 #### Fixed
-- Fixed groups from sources outside a project spec's directory from being flattened. [#550](https://github.com/yonaskolb/XcodeGen/pull/550) @sroebert
-- Fixed `optional` file sources not being added to the project [#557](https://github.com/yonaskolb/XcodeGen/pull/557) @yonaskolb
-- Fixed Carthage dependencies being incorrectly embedded in WatchKit app bundles instead of a WatchKit app extension [#558](https://github.com/yonaskolb/XcodeGen/pull/558) @KhaosT
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.4.0...2.5.0)
+- Fixed groups from sources outside a project spec's directory from being flattened. #550 @sroebert
+- Fixed `optional` file sources not being added to the project #557 @yonaskolb
+- Fixed Carthage dependencies being incorrectly embedded in WatchKit app bundles instead of a WatchKit app extension #558 @KhaosT
 
 ## 2.4.0
 
 #### Fixed:
-- Fixed installation when building in Swift 5 [#549](https://github.com/yonaskolb/XcodeGen/pull/549) @yonaskolb
+- Fixed installation when building in Swift 5 #549 @yonaskolb
 
 #### Changed
-- Updated to Swift 5 and dropped Swift 4.2 [#549](https://github.com/yonaskolb/XcodeGen/pull/549) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.3.0...2.4.0)
+- Updated to Swift 5 and dropped Swift 4.2 #549 @yonaskolb
 
 ## 2.3.0
 
 #### Added
-- Added ability to automatically find all the frameworks for Carthage dependencies via the global `options.findCarthageFrameworks` or dependency specfic `dependency.findFrameworks`. See the [Carthage](Docs/Usage.md#carthage) usage docs for more info [#506](https://github.com/yonaskolb/XcodeGen/pull/506) [#543](https://github.com/yonaskolb/XcodeGen/pull/543) @rpassis @yonaskolb
-- Added support for nested target templates [#534](https://github.com/yonaskolb/XcodeGen/pull/534) @tomquist
-- Added ability to define `templateAttributes` within a target to be able to parameterize templates. [#533](https://github.com/yonaskolb/XcodeGen/pull/533) @tomquist
-- Added ability to set `link` to false in framework dependencies [#532](https://github.com/yonaskolb/XcodeGen/pull/532) @dimatosaurus
+- Added ability to automatically find all the frameworks for Carthage dependencies via the global `options.findCarthageFrameworks` or dependency specfic `dependency.findFrameworks`. See the [Carthage](Docs/Usage.md#carthage) usage docs for more info #506 @rpassis @yonaskolb
+- Added support for nested target templates #534 @tomquist
+- Added ability to define `templateAttributes` within a target to be able to parameterize templates. #533 @tomquist
+- Added ability to set `link` to false in framework dependencies #532 @dimatosaurus
 - Added `missingConfigFiles` to `options.disabledValidations` to optionally skip checking for the existence of config files.
-- Added ability to define a per-platform `deploymentTarget` for Multi-Platform targets. [#510](https://github.com/yonaskolb/XcodeGen/pull/510) @ainopara
+- Added ability to define a per-platform `deploymentTarget` for Multi-Platform targets. #510 @ainopara
 
 #### Changed
-- **DEPRECATION**: Placeholders `$target_name` and `$platform` have been deprecated in favour of `${target_name}` and `${platform}`. Support for the old placeholders will be removed in a future version [#533](https://github.com/yonaskolb/XcodeGen/pull/533) @tomquist
+- **DEPRECATION**: Placeholders `$target_name` and `$platform` have been deprecated in favour of `${target_name}` and `${platform}`. Support for the old placeholders will be removed in a future version #533 @tomquist
 
 #### Fixed
-- Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. [#524](https://github.com/yonaskolb/XcodeGen/pull/524)
-- Fixed error when `optional` directory source is missing [#527](https://github.com/yonaskolb/XcodeGen/pull/527) @yonaskolb
-- Fixed excludes within included spec [#535](https://github.com/yonaskolb/XcodeGen/pull/535) @yonaskolb
-- Fixed paths in target templates within included files not being relative [#537](https://github.com/yonaskolb/XcodeGen/pull/537) @yonaskolb
-- Fix multi-platform target templates [#541](https://github.com/yonaskolb/XcodeGen/pull/541) @yonaskolb
-- Fixed sources in an included target not being relative when the sources are mix of string and dictionaries [#542](https://github.com/yonaskolb/XcodeGen/pull/542) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.2.0...2.3.0)
+- Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. #524
+- Fixed error when `optional` directory source is missing #527 @yonaskolb
+- Fixed excludes within included spec #535 @yonaskolb
+- Fixed paths in target templates within included files not being relative #537 @yonaskolb
+- Fix multi-platform target templates #541 @yonaskolb
+- Fixed sources in an included target not being relative when the sources are mix of string and dictionaries #542 @yonaskolb
 
 ## 2.2.0
 
 #### Added
-- Added ability to generate empty directories via `options.generateEmptyDirectories` [#480](https://github.com/yonaskolb/XcodeGen/pull/480) @Beniamiiin
-- Added support for the `instrumentsPackage` product type [#482](https://github.com/yonaskolb/XcodeGen/pull/482) @ksulliva
-- Added support for `inputFileLists` and `outputFileLists` within project build scripts [#500](https://github.com/yonaskolb/XcodeGen/pull/500) @lukewakeford
-- Added support for a `$target_name` replacement string within target templates [#504](https://github.com/yonaskolb/XcodeGen/pull/504) @yonaskolb
-- Added `createIntermediateGroups` to individual Target Sources which overrides the top level option [#505](https://github.com/yonaskolb/XcodeGen/pull/505) @yonaskolb
+- Added ability to generate empty directories via `options.generateEmptyDirectories` #480 @Beniamiiin
+- Added support for the `instrumentsPackage` product type #482 @ksulliva
+- Added support for `inputFileLists` and `outputFileLists` within project build scripts #500 @lukewakeford
+- Added support for a `$target_name` replacement string within target templates #504 @yonaskolb
+- Added `createIntermediateGroups` to individual Target Sources which overrides the top level option #505 @yonaskolb
 
 #### Changed
-- **BREAKING**: All the paths within `include` files are now relative to that file and not the root spec. This can be disabled with a `relativePaths: false` on the include. See the [documentation](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#include) for more details [#489](https://github.com/yonaskolb/XcodeGen/pull/489) @ellneal
-- Updated the Xcode compatibility version from 3.2 to 9.3 [#497](https://github.com/yonaskolb/XcodeGen/pull/497) @yonaskolb
-- Exact matches to config names in build settings won't partial apply to other configs [#503](https://github.com/yonaskolb/XcodeGen/pull/503) @yonaskolb
+- **BREAKING**: All the paths within `include` files are now relative to that file and not the root spec. This can be disabled with a `relativePaths: false` on the include. See the [documentation](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#include) for more details #489 @ellneal
+- Updated the Xcode compatibility version from 3.2 to 9.3 #497 @yonaskolb
+- Exact matches to config names in build settings won't partial apply to other configs #503 @yonaskolb
 - UUIDs in the project are standard and don't contain any type prefixes anymore
 
 #### Fixed
-- Fixed `--project` argument not taking effect [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
-- Fixed Sticker Packs from generating an empty Source file phase which caused in error in the new build system [#492](https://github.com/yonaskolb/XcodeGen/pull/492) @rpassis
-- Fixed generated schemes for tool targets not setting the executable [#496](https://github.com/yonaskolb/XcodeGen/pull/496) @yonaskolb
+- Fixed `--project` argument not taking effect #487 @monowerker
+- Fixed Sticker Packs from generating an empty Source file phase which caused in error in the new build system #492 @rpassis
+- Fixed generated schemes for tool targets not setting the executable #496 @yonaskolb
 - Fixed resolving Carthage dependencies for iOS app with watchOS target. [465](https://github.com/yonaskolb/XcodeGen/pull/465) @raptorxcz
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.1.0...2.2.0)
 
 ## 2.1.0
 
 #### Added
-- Added an experiment new caching feature. Pass `--use-cache` to opt in. This will read and write from a cache file to prevent unnecessarily generating the project. Give it a try as it may become the default in a future release [#412](https://github.com/yonaskolb/XcodeGen/pull/412) @yonaskolb
+- Added an experiment new caching feature. Pass `--use-cache` to opt in. This will read and write from a cache file to prevent unnecessarily generating the project. Give it a try as it may become the default in a future release #412 @yonaskolb
 
 #### Changed
 - Changed spelling of build phases to **preBuildPhase** and **postBuildPhase**. The older names are deprecated but still work [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones
-- Moved generation to a specific subcommand `xcodegen generate`. Simple `xcodegen` will continue to work for now [#437](https://github.com/yonaskolb/XcodeGen/pull/437) @yonaskolb
-- If `INFOPLIST_FILE` has been set on a target, then an `info` path won't ovewrite it [#443](https://github.com/yonaskolb/XcodeGen/pull/443) @feischl97
+- Moved generation to a specific subcommand `xcodegen generate`. Simple `xcodegen` will continue to work for now #437 @yonaskolb
+- If `INFOPLIST_FILE` has been set on a target, then an `info` path won't ovewrite it #443 @feischl97
 
 #### Fixed
-- Fixed XPC Service package type in generated `Info.plist` [#435](https://github.com/yonaskolb/XcodeGen/pull/435) @alvarhansen
+- Fixed XPC Service package type in generated `Info.plist` #435 @alvarhansen
 - Fixed phase ordering for modulemap and static libary header Copy File phases. [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones
-- Fixed intermittent errors when running multiple `xcodegen`s concurrently [#450](https://github.com/yonaskolb/XcodeGen/pull/450) @bryansum
-- Fixed `--project` argument not working [#437](https://github.com/yonaskolb/XcodeGen/pull/437) @yonaskolb
-- Fixed unit tests not hooking up to host applications properly by default. They now generate a `TEST_HOST` and a `TestTargetID` [#452](https://github.com/yonaskolb/XcodeGen/pull/452) @yonaskolb
-- Fixed static libraries not including external frameworks in their search paths [#454](https://github.com/yonaskolb/XcodeGen/pull/454) @brentleyjones
-- Add `.intentdefinition` files to sources build phase instead of resources [#442](https://github.com/yonaskolb/XcodeGen/pull/442) @yonaskolb
-- Add `mlmodel` files to sources build phase instead of resources [#457](https://github.com/yonaskolb/XcodeGen/pull/457) @dwb357
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.0.0...2.1.0)
+- Fixed intermittent errors when running multiple `xcodegen`s concurrently #450 @bryansum
+- Fixed `--project` argument not working #437 @yonaskolb
+- Fixed unit tests not hooking up to host applications properly by default. They now generate a `TEST_HOST` and a `TestTargetID` #452 @yonaskolb
+- Fixed static libraries not including external frameworks in their search paths #454 @brentleyjones
+- Add `.intentdefinition` files to sources build phase instead of resources #442 @yonaskolb
+- Add `mlmodel` files to sources build phase instead of resources #457 @dwb357
 
 ## 2.0.0
 
 #### Added
-- Added `weak` linking setting for dependencies [#411](https://github.com/yonaskolb/XcodeGen/pull/411) @alvarhansen
-- Added `info` to targets for generating an `Info.plist` [#415](https://github.com/yonaskolb/XcodeGen/pull/415) @yonaskolb
-- Added `entitlements` to targets for generating an `.entitlement` file [#415](https://github.com/yonaskolb/XcodeGen/pull/415) @yonaskolb
-- Added `sdk` dependency type for linking system frameworks and libs [#430](https://github.com/yonaskolb/XcodeGen/pull/430) @yonaskolb
-- Added `parallelizable` and `randomExecutionOrder` to `Scheme` test targets in an expanded form [#434](https://github.com/yonaskolb/XcodeGen/pull/434) @yonaskolb
-- Validate incorrect config setting definitions [#431](https://github.com/yonaskolb/XcodeGen/pull/431) @yonaskolb
-- Automatically set project `SDKROOT` if there is only a single platform within the project [#433](https://github.com/yonaskolb/XcodeGen/pull/433) @yonaskolb
+- Added `weak` linking setting for dependencies #411 @alvarhansen
+- Added `info` to targets for generating an `Info.plist` #415 @yonaskolb
+- Added `entitlements` to targets for generating an `.entitlement` file #415 @yonaskolb
+- Added `sdk` dependency type for linking system frameworks and libs #430 @yonaskolb
+- Added `parallelizable` and `randomExecutionOrder` to `Scheme` test targets in an expanded form #434 @yonaskolb
+- Validate incorrect config setting definitions #431 @yonaskolb
+- Automatically set project `SDKROOT` if there is only a single platform within the project #433 @yonaskolb
 
 #### Changed
-- Performance improvements for large projects [#388](https://github.com/yonaskolb/XcodeGen/pull/388) [#417](https://github.com/yonaskolb/XcodeGen/pull/417) [#416](https://github.com/yonaskolb/XcodeGen/pull/416) @yonaskolb @kastiglione
-- Upgraded to xcodeproj 6 [#388](https://github.com/yonaskolb/XcodeGen/pull/388) @yonaskolb
-- Upgraded to Swift 4.2 [#388](https://github.com/yonaskolb/XcodeGen/pull/388) @yonaskolb
-- Remove iOS codesigning sdk restriction in setting preset [#414](https://github.com/yonaskolb/XcodeGen/pull/414) @yonaskolb
-- Changed default project version to Xcode 10.0 and default Swift version to 4.2 [#423](https://github.com/yonaskolb/XcodeGen/pull/423) @yonaskolb
-- Added ability to not link Carthage frameworks [#432](https://github.com/yonaskolb/XcodeGen/pull/432) @yonaskolb
+- Performance improvements for large projects #388 @yonaskolb @kastiglione
+- Upgraded to xcodeproj 6 #388 @yonaskolb
+- Upgraded to Swift 4.2 #388 @yonaskolb
+- Remove iOS codesigning sdk restriction in setting preset #414 @yonaskolb
+- Changed default project version to Xcode 10.0 and default Swift version to 4.2 #423 @yonaskolb
+- Added ability to not link Carthage frameworks #432 @yonaskolb
 
 #### Fixed
-- Fixed code signing issues [#414](https://github.com/yonaskolb/XcodeGen/pull/414) @yonaskolb
-- Fixed `TargetSource.headerVisibility` not being set in initializer [#419](https://github.com/yonaskolb/XcodeGen/pull/419) @jerrymarino
-- Fixed crash when using Xcode Legacy targets as dependencies [#427](https://github.com/yonaskolb/XcodeGen/pull/427) @dflems
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.11.2...2.0.0)
+- Fixed code signing issues #414 @yonaskolb
+- Fixed `TargetSource.headerVisibility` not being set in initializer #419 @jerrymarino
+- Fixed crash when using Xcode Legacy targets as dependencies #427 @dflems
 
 ## 1.11.2
 
 If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project will not be deterministic. This will be fixed in an upcoming release with an update to xcodeproj 6.0
 
 #### Fixed
-- Fixed release builds in Swift 4.2 [#404](https://github.com/yonaskolb/XcodeGen/pull/404) @pepibumur
-- Fixed default settings for macOS unit-tests [#387](https://github.com/yonaskolb/XcodeGen/pull/387) @frankdilo
-- Fixed Copy Headers phase ordering for Xcode 10 [#401](https://github.com/yonaskolb/XcodeGen/pull/401) @brentleyjones
-- Fixed generated schemes on aggregate targets [#394](https://github.com/yonaskolb/XcodeGen/pull/394) @vgorloff
+- Fixed release builds in Swift 4.2 #404 @pepibumur
+- Fixed default settings for macOS unit-tests #387 @frankdilo
+- Fixed Copy Headers phase ordering for Xcode 10 #401 @brentleyjones
+- Fixed generated schemes on aggregate targets #394 @vgorloff
 
 #### Changed
-- Added `en` as default value for knownRegions [#390](https://github.com/yonaskolb/XcodeGen/pull/390) @Saik0s
+- Added `en` as default value for knownRegions #390 @Saik0s
 - Update `PathKit`, `Spectre`, `Yams` and `xcodeproj` dependencies
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.11.1...1.11.2)
 
 ## 1.11.1
 
 #### Fixed
-- Fixed `FRAMEWORK_SEARCH_PATHS` for `framework` dependency paths with spaces [#382](https://github.com/yonaskolb/XcodeGen/pull/382) @brentleyjones
-- Fixed aggregate targets not being found with `transitivelyLinkDependencies` [#383](https://github.com/yonaskolb/XcodeGen/pull/383) @brentleyjones
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.11.0...1.11.1)
+- Fixed `FRAMEWORK_SEARCH_PATHS` for `framework` dependency paths with spaces #382 @brentleyjones
+- Fixed aggregate targets not being found with `transitivelyLinkDependencies` #383 @brentleyjones
 
 ## 1.11.0
 
 #### Added
-- Added `showEnvVars` to build scripts to disable printing the environment [#351](https://github.com/yonaskolb/XcodeGen/pull/351) @keith
-- Added `requiresObjCLinking` to `target` [#354](https://github.com/yonaskolb/XcodeGen/pull/354) @brentleyjones
-- Added `targetTemplates` [#355](https://github.com/yonaskolb/XcodeGen/pull/355) @yonaskolb
-- Added `aggregateTargets` [#353](https://github.com/yonaskolb/XcodeGen/pull/353) [#381](https://github.com/yonaskolb/XcodeGen/pull/381) @yonaskolb
-- Added `options.groupSortPosition` [#356](https://github.com/yonaskolb/XcodeGen/pull/356) @yonaskolb
-- Added ability to specify `copyFiles` build phase for sources [#345](https://github.com/yonaskolb/XcodeGen/pull/345) @brentleyjones
-- Added ability to specify a `minimumXcodeGenVersion` [#349](https://github.com/yonaskolb/XcodeGen/pull/349) @brentleyjones
-- Added `customArchiveName` and `revealArchiveInOrganizer` to `archive`  [#367](https://github.com/yonaskolb/XcodeGen/pull/367) @sxua
+- Added `showEnvVars` to build scripts to disable printing the environment #351 @keith
+- Added `requiresObjCLinking` to `target` #354 @brentleyjones
+- Added `targetTemplates` #355 @yonaskolb
+- Added `aggregateTargets` #353 @yonaskolb
+- Added `options.groupSortPosition` #356 @yonaskolb
+- Added ability to specify `copyFiles` build phase for sources #345 @brentleyjones
+- Added ability to specify a `minimumXcodeGenVersion` #349 @brentleyjones
+- Added `customArchiveName` and `revealArchiveInOrganizer` to `archive`  #367 @sxua
 
 #### Fixed
-- Sort files using localizedStandardCompare [#341](https://github.com/yonaskolb/XcodeGen/pull/341) @rohitpal440
-- Use the latest `xcdatamodel` when sorted by version [#341](https://github.com/yonaskolb/XcodeGen/pull/341) @rohitpal440
-- Fixed compiler flags being set on non source files in mixed build phase target sources [#347](https://github.com/yonaskolb/XcodeGen/pull/347) @brentleyjones
-- Fixed `options.xcodeVersion` not being parsed [#348](https://github.com/yonaskolb/XcodeGen/pull/348) @brentleyjones
-- Fixed non-application targets using `carthage copy-frameworks` [#361](https://github.com/yonaskolb/XcodeGen/pull/361) @brentleyjones
-- Set `xcdatamodel` based on `xccurrentversion` if available [#364](https://github.com/yonaskolb/XcodeGen/pull/364) @rpassis
-- XPC Services are now correctly copied [#368](https://github.com/yonaskolb/XcodeGen/pull/368) @brentley
-- Fixed `.metal` files being added to resources [#380](https://github.com/yonaskolb/XcodeGen/pull/380) @vgorloff
+- Sort files using localizedStandardCompare #341 @rohitpal440
+- Use the latest `xcdatamodel` when sorted by version #341 @rohitpal440
+- Fixed compiler flags being set on non source files in mixed build phase target sources #347 @brentleyjones
+- Fixed `options.xcodeVersion` not being parsed #348 @brentleyjones
+- Fixed non-application targets using `carthage copy-frameworks` #361 @brentleyjones
+- Set `xcdatamodel` based on `xccurrentversion` if available #364 @rpassis
+- XPC Services are now correctly copied #368 @brentley
+- Fixed `.metal` files being added to resources #380 @vgorloff
 
 #### Changed
-- Improved linking for `static.library` targets [#352](https://github.com/yonaskolb/XcodeGen/pull/352) @brentleyjones
-- Changed default group sorting to be after files [#356](https://github.com/yonaskolb/XcodeGen/pull/356) @yonaskolb
-- Moved `Frameworks` and `Products` top level groups to bottom [#356](https://github.com/yonaskolb/XcodeGen/pull/356) @yonaskolb
-- `modulemap` files are automatically copied to the products directory for static library targets [#346](https://github.com/yonaskolb/XcodeGen/pull/346) @brentleyjones
-- Public header files are automatically copied to the products directory for static library targets [#365](https://github.com/yonaskolb/XcodeGen/pull/365) @brentleyjones
-- Swift Objective-C Interface Header files are automatically copied to the products directory for static library targets [#366](https://github.com/yonaskolb/XcodeGen/pull/366) @brentleyjones
-- `FRAMEWORK_SEARCH_PATHS` are adjusted for `framework` dependencies [#373](https://github.com/yonaskolb/XcodeGen/pull/373) @brentley
-- `library.static` targets have `SKIP_INSTALL` set to `YES` [#358](https://github.com/yonaskolb/XcodeGen/pull/358) @brentley
-- Copy files phases have descriptive names [#360](https://github.com/yonaskolb/XcodeGen/pull/360) @brentley
+- Improved linking for `static.library` targets #352 @brentleyjones
+- Changed default group sorting to be after files #356 @yonaskolb
+- Moved `Frameworks` and `Products` top level groups to bottom #356 @yonaskolb
+- `modulemap` files are automatically copied to the products directory for static library targets #346 @brentleyjones
+- Public header files are automatically copied to the products directory for static library targets #365 @brentleyjones
+- Swift Objective-C Interface Header files are automatically copied to the products directory for static library targets #366 @brentleyjones
+- `FRAMEWORK_SEARCH_PATHS` are adjusted for `framework` dependencies #373 @brentley
+- `library.static` targets have `SKIP_INSTALL` set to `YES` #358 @brentley
+- Copy files phases have descriptive names #360 @brentley
 
 #### Internal
 - Moved brew formula to homebrew core
 - Added `CONTRIBUTING.md`
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.10.3...1.11.0)
-
 ## 1.10.3
 
 #### Fixed
-- Fixed Mint installations finding `SettingPresets` [#338](https://github.com/yonaskolb/XcodeGen/pull/338) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.10.2...1.10.3)
+- Fixed Mint installations finding `SettingPresets` #338 @yonaskolb
 
 ## 1.10.2
 
 #### Changed
 - Set `transitivelyLinkDependencies` to false by default
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.10.1...1.10.2)
-
 ## 1.10.1
 
 #### Fixed
-- Fixed `transitivelyLinkDependencies` typo [#332](https://github.com/yonaskolb/XcodeGen/pull/332) @brentleyjones
-- Fixed framework target dependencies not being code signed by default [#332](https://github.com/yonaskolb/XcodeGen/pull/332) @yonaskolb
+- Fixed `transitivelyLinkDependencies` typo #332 @brentleyjones
+- Fixed framework target dependencies not being code signed by default #332 @yonaskolb
 
 #### Changed
-- Code sign all dependencies by default except target executables [#332](https://github.com/yonaskolb/XcodeGen/pull/332) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.10.0...1.10.1)
+- Code sign all dependencies by default except target executables #332 @yonaskolb
 
 ## 1.10.0
 
 #### Added
-- Added build rule support [#306](https://github.com/yonaskolb/XcodeGen/pull/306) @yonaskolb
-- Added support for frameworks in sources [#308](https://github.com/yonaskolb/XcodeGen/pull/308) @keith
-- Added ability to automatically embed transient dependencies. Controlled with `transitivelyLinkDependencies` [#327](https://github.com/yonaskolb/XcodeGen/pull/327) @brentleyjones
+- Added build rule support #306 @yonaskolb
+- Added support for frameworks in sources #308 @keith
+- Added ability to automatically embed transient dependencies. Controlled with `transitivelyLinkDependencies` #327 @brentleyjones
 
 #### Changed
 - Upgraded to Swift 4.1
-- Improved Carthage dependency lookup performance with many targets [#298](https://github.com/yonaskolb/XcodeGen/pull/298) @keith
-- By default don't CodeSignOnCopy `target` dependencies. This can still be controlled with `Dependency.codeSign` [#324](https://github.com/yonaskolb/XcodeGen/pull/324) @yonaskolb
+- Improved Carthage dependency lookup performance with many targets #298 @keith
+- By default don't CodeSignOnCopy `target` dependencies. This can still be controlled with `Dependency.codeSign` #324 @yonaskolb
 
 #### Fixed
-- Fixed PBXBuildFile and PBXFileReference being incorrectly generated for Legacy targets [#296](https://github.com/yonaskolb/XcodeGen/pull/296) @sascha
-- Fixed required sources build phase not being generated if there are no sources [#307](https://github.com/yonaskolb/XcodeGen/pull/307) @yonaskolb
-- Fixed install script in binary release [#303](https://github.com/yonaskolb/XcodeGen/pull/303) @alvarhansen
-- Removed `ENABLE_TESTABILITY` from framework setting presets [#299](https://github.com/yonaskolb/XcodeGen/pull/299) @allu22
-- Fixed homebrew installation [#297](https://github.com/yonaskolb/XcodeGen/pull/297) @vhbit
-- `cc` files are now automatically recognized as source files [#317](https://github.com/yonaskolb/XcodeGen/pull/317) @maicki
-- Fixed `commandLineArguments` not parsing when they had dots in them [#323](https://github.com/yonaskolb/XcodeGen/pull/323) @yonaskolb
-- Fixed excluding directories that only have sub directories [#326](https://github.com/yonaskolb/XcodeGen/pull/326) @brentleyjones
+- Fixed PBXBuildFile and PBXFileReference being incorrectly generated for Legacy targets #296 @sascha
+- Fixed required sources build phase not being generated if there are no sources #307 @yonaskolb
+- Fixed install script in binary release #303 @alvarhansen
+- Removed `ENABLE_TESTABILITY` from framework setting presets #299 @allu22
+- Fixed homebrew installation #297 @vhbit
+- `cc` files are now automatically recognized as source files #317 @maicki
+- Fixed `commandLineArguments` not parsing when they had dots in them #323 @yonaskolb
+- Fixed excluding directories that only have sub directories #326 @brentleyjones
 - Made `PBXContainerItemProxy` ID more deterministic
-- Fixed generated framework schemes from being executable [#328](https://github.com/yonaskolb/XcodeGen/pull/328) @brentleyjones
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.9.0...1.10.0)
+- Fixed generated framework schemes from being executable #328 @brentleyjones
 
 ## 1.9.0
 
 #### Added
-- Scheme pre and post actions can now be added to `target.scheme` [#280](https://github.com/yonaskolb/XcodeGen/pull/280) @yonaskolb
-- Individual files can now be added to `fileGroups` [#293](https://github.com/yonaskolb/XcodeGen/pull/293) @yonaskolb
+- Scheme pre and post actions can now be added to `target.scheme` #280 @yonaskolb
+- Individual files can now be added to `fileGroups` #293 @yonaskolb
 
 #### Changed
 - Updated to `xcproj` 4.3.0 for Xcode 9.3 updates
-- Update default Xcode version to 9.3 including new settings [#284](https://github.com/yonaskolb/XcodeGen/pull/284) @LinusU
-- **Breaking for ProjectSpec library users** Changed `ProjectSpec` to `Project` and `ProjectSpec.Options` to `SpecOptions`  [#281](https://github.com/yonaskolb/XcodeGen/pull/281) @jerrymarino
+- Update default Xcode version to 9.3 including new settings #284 @LinusU
+- **Breaking for ProjectSpec library users** Changed `ProjectSpec` to `Project` and `ProjectSpec.Options` to `SpecOptions`  #281 @jerrymarino
 
 #### Fixed
-- Fixed manual build phase of `none` not being applied to folders [#288](https://github.com/yonaskolb/XcodeGen/pull/288) @yonaskolb
-- Quoted values now correctly get parsed as strings [#282](https://github.com/yonaskolb/XcodeGen/pull/282) @yonaskolb
-- Fixed adding a root source folder when `createIntermediateGroups` is on [#291](https://github.com/yonaskolb/XcodeGen/pull/291) @yonaskolb
-- Fixed Homebrew installations issues on some machines [#289](https://github.com/yonaskolb/XcodeGen/pull/289) @vhbit
-- Fixed files that are added as root sources from having invalid parent groups outside the project directory [#293](https://github.com/yonaskolb/XcodeGen/pull/293) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.8.0...1.9.0)
+- Fixed manual build phase of `none` not being applied to folders #288 @yonaskolb
+- Quoted values now correctly get parsed as strings #282 @yonaskolb
+- Fixed adding a root source folder when `createIntermediateGroups` is on #291 @yonaskolb
+- Fixed Homebrew installations issues on some machines #289 @vhbit
+- Fixed files that are added as root sources from having invalid parent groups outside the project directory #293 @yonaskolb
 
 ## 1.8.0
 
 #### Added
-- Added Project `defaultConfig` [#269](https://github.com/yonaskolb/XcodeGen/pull/269) @keith
-- Added Target `attributes` [#276](https://github.com/yonaskolb/XcodeGen/pull/276) @yonaskolb
-- Automatically set `DevelopmentTeam` and `ProvisioningStyle` within `TargetAttributes` if relevant build settings are defined [#277](https://github.com/yonaskolb/XcodeGen/pull/277) @yonaskolb
+- Added Project `defaultConfig` #269 @keith
+- Added Target `attributes` #276 @yonaskolb
+- Automatically set `DevelopmentTeam` and `ProvisioningStyle` within `TargetAttributes` if relevant build settings are defined #277 @yonaskolb
 
 #### Fixed
-- Fixed default `LD_RUNPATH_SEARCH_PATHS` for app extensions [#272](https://github.com/yonaskolb/XcodeGen/pull/272) @LinusU
+- Fixed default `LD_RUNPATH_SEARCH_PATHS` for app extensions #272 @LinusU
 
 #### Internal
-- Make `LegacyTarget` init public [#264](https://github.com/yonaskolb/XcodeGen/pull/264) @jerrymarino
+- Make `LegacyTarget` init public #264 @jerrymarino
 - Upgrade to *xcproj* to 4.2.0, *Yams* to 0.6.0 and *PathKit* to 0.9.1 @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.7.0...1.8.0)
 
 ## 1.7.0
 
 #### Added
 
-- Added support for scheme environment variables [#239](https://github.com/yonaskolb/XcodeGen/pull/239) [#254](https://github.com/yonaskolb/XcodeGen/pull/254) [#259](https://github.com/yonaskolb/XcodeGen/pull/259) @turekj @toshi0383
-- Added `carthageExecutablePath` option [#244](https://github.com/yonaskolb/XcodeGen/pull/244) @akkyie
-- Added `parallelizeBuild` and `buildImplicitDependencies` to Schemes [#241](https://github.com/yonaskolb/XcodeGen/pull/241) @rahul-malik
+- Added support for scheme environment variables #239 @turekj @toshi0383
+- Added `carthageExecutablePath` option #244 @akkyie
+- Added `parallelizeBuild` and `buildImplicitDependencies` to Schemes #241 @rahul-malik
  @yonaskolb
-- Added support for Core Data `xcdatamodeld` files [#249](https://github.com/yonaskolb/XcodeGen/pull/249) @yonaskolb
-- Projects are now generated atomically by writing to a temporary directory first [#250](https://github.com/yonaskolb/XcodeGen/pull/250) @yonaskolb
-- Added script for adding precompiled binary to releases [#246](https://github.com/yonaskolb/XcodeGen/pull/246) @toshi0383
-- Added optional `headerVisibilty` to target source. This still defaults to public [#252](https://github.com/yonaskolb/XcodeGen/pull/252) @yonaskolb
+- Added support for Core Data `xcdatamodeld` files #249 @yonaskolb
+- Projects are now generated atomically by writing to a temporary directory first #250 @yonaskolb
+- Added script for adding precompiled binary to releases #246 @toshi0383
+- Added optional `headerVisibilty` to target source. This still defaults to public #252 @yonaskolb
 - Releases now include a pre-compiled binary and setting presets, including an install script
 
 #### Fixed
-- Fixed Mint installation from reading setting presets [#248](https://github.com/yonaskolb/XcodeGen/pull/248) @yonaskolb
-- Fixed setting `buildPhase` on a `folder` source. This allows for a folder of header files [#254](https://github.com/yonaskolb/XcodeGen/pull/254) @toshi0383
-- Carthage dependencies are not automatically embedded into test targets [#256](https://github.com/yonaskolb/XcodeGen/pull/256) @yonaskolb
-- Carthage dependencies now respect the `embed` property [#256](https://github.com/yonaskolb/XcodeGen/pull/256) @yonaskolb
-- iMessage extensions now have proper setting presets in regards to app icon and runtime search paths [#255](https://github.com/yonaskolb/XcodeGen/pull/255) @yonaskolb
-- Excluded files are not added within .lproj directories [#238](https://github.com/yonaskolb/XcodeGen/pull/238) @toshi0383
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.6.0...1.7.0)
+- Fixed Mint installation from reading setting presets #248 @yonaskolb
+- Fixed setting `buildPhase` on a `folder` source. This allows for a folder of header files #254 @toshi0383
+- Carthage dependencies are not automatically embedded into test targets #256 @yonaskolb
+- Carthage dependencies now respect the `embed` property #256 @yonaskolb
+- iMessage extensions now have proper setting presets in regards to app icon and runtime search paths #255 @yonaskolb
+- Excluded files are not added within .lproj directories #238 @toshi0383
 
 ## 1.6.0
 
 #### Added
-- Added scheme pre-actions and post-actions [#231](https://github.com/yonaskolb/XcodeGen/pull/231) @kastiglione
-- Added `options.disabledValidations` including `missingConfigs` to disable project validation errors [#220](https://github.com/yonaskolb/XcodeGen/pull/220) @keith
-- Generate UI Test Target Attributes [#221](https://github.com/yonaskolb/XcodeGen/pull/221) @anreitersimon
+- Added scheme pre-actions and post-actions #231 @kastiglione
+- Added `options.disabledValidations` including `missingConfigs` to disable project validation errors #220 @keith
+- Generate UI Test Target Attributes #221 @anreitersimon
 
 #### Fixed
-- Filter out duplicate source files [#217](https://github.com/yonaskolb/XcodeGen/pull/217) @allu22
-- Fixed how `lastKnownFileType` and `explicitFileType` were generated across platforms [#115](https://github.com/yonaskolb/XcodeGen/pull/115) @toshi0383
+- Filter out duplicate source files #217 @allu22
+- Fixed how `lastKnownFileType` and `explicitFileType` were generated across platforms #115 @toshi0383
 - Removed a few cases of project diffs when opening the project in Xcode @yonaskolb
 - Fixed Swift not being embedded by default in watch apps @yonaskolb
 
 #### Changed
-- Change arrays to strings in setting presets [#218](https://github.com/yonaskolb/XcodeGen/pull/218) @allu22
-- Updated to xcproj 4.0 [#227](https://github.com/yonaskolb/XcodeGen/pull/227)
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.5.0...1.6.0)
+- Change arrays to strings in setting presets #218 @allu22
+- Updated to xcproj 4.0 #227
 
 ## 1.5.0
 
 #### Added
-- added support for `gatherCoverageData` flag in target schemes [#170](https://github.com/yonaskolb/XcodeGen/pull/170) @alexruperez
-- added support for `commandLineOptions` in target schemes [#172](https://github.com/yonaskolb/XcodeGen/pull/172) @rahul-malik
-- added Project spec as a SwiftPM library for reuse in other projects [#164](https://github.com/yonaskolb/XcodeGen/pull/164) @soffes
-- added `implicit` option for framework dependencies [#166](https://github.com/yonaskolb/XcodeGen/pull/166) @sbarow
-- added `--quite` option to CLI [#167](https://github.com/yonaskolb/XcodeGen/pull/167) @soffes
-- can now print version with `-v` in addition to `--version` [#174](https://github.com/yonaskolb/XcodeGen/pull/174) @kastiglione
-- added support for legacy targets [#175](https://github.com/yonaskolb/XcodeGen/pull/175) @bkase
-- added support for indentation options [#190](https://github.com/yonaskolb/XcodeGen/pull/190) @bkase
-- added source excludes [#135](https://github.com/yonaskolb/XcodeGen/pull/135) [#161](https://github.com/yonaskolb/XcodeGen/pull/161) [#190](https://github.com/yonaskolb/XcodeGen/pull/190) @peymankh @
-- added `options.xcodeVersion` [#197](https://github.com/yonaskolb/XcodeGen/pull/197) @yonaskolb @peymankh
-- add test targets to Scheme [#195](https://github.com/yonaskolb/XcodeGen/pull/195) @vhbit
-- add option to make a source file optional incase it will be generated later [#200](https://github.com/yonaskolb/XcodeGen/pull/200) @vhbit
-- finalize Scheme spec [#201](https://github.com/yonaskolb/XcodeGen/pull/201) @yonaskolb
-- added `buildPhase` setting to target source for overriding the guessed build phase of files [#206](https://github.com/yonaskolb/XcodeGen/pull/206) @yonaskolb
-- added `deploymentTarget` setting to project and target [#205](https://github.com/yonaskolb/XcodeGen/pull/205) @yonaskolb
+- added support for `gatherCoverageData` flag in target schemes #170 @alexruperez
+- added support for `commandLineOptions` in target schemes #172 @rahul-malik
+- added Project spec as a SwiftPM library for reuse in other projects #164 @soffes
+- added `implicit` option for framework dependencies #166 @sbarow
+- added `--quite` option to CLI #167 @soffes
+- can now print version with `-v` in addition to `--version` #174 @kastiglione
+- added support for legacy targets #175 @bkase
+- added support for indentation options #190 @bkase
+- added source excludes #135 @peymankh @
+- added `options.xcodeVersion` #197 @yonaskolb @peymankh
+- add test targets to Scheme #195 @vhbit
+- add option to make a source file optional incase it will be generated later #200 @vhbit
+- finalize Scheme spec #201 @yonaskolb
+- added `buildPhase` setting to target source for overriding the guessed build phase of files #206 @yonaskolb
+- added `deploymentTarget` setting to project and target #205 @yonaskolb
 
 #### Changed
 - huge performance improvements when writing the project file due to changes in xcproj
 - updated dependencies
 - minor logging changes
 - updated Project Spec documentation
-- scan for `Info.plist` lazely [#194](https://github.com/yonaskolb/XcodeGen/pull/194) @kastiglione
-- change setting presets so that icon settings only get applied to application targets [#204](https://github.com/yonaskolb/XcodeGen/pull/204) @yonaskolb
-- changed scheme build targets format [#203](https://github.com/yonaskolb/XcodeGen/pull/203) @yonaskolb
-- when specifying a `--spec` argument, the default for the `--project` path is now the directory containing the spec [#211](https://github.com/yonaskolb/XcodeGen/pull/211) @yonaskolb
+- scan for `Info.plist` lazely #194 @kastiglione
+- change setting presets so that icon settings only get applied to application targets #204 @yonaskolb
+- changed scheme build targets format #203 @yonaskolb
+- when specifying a `--spec` argument, the default for the `--project` path is now the directory containing the spec #211 @yonaskolb
 
 #### Fixed
-- fixed shell scripts escaping quotes twice [#186](https://github.com/yonaskolb/XcodeGen/pull/186) @allu22
-- fixed `createIntermediateGroups` when using a relative spec path [#184](https://github.com/yonaskolb/XcodeGen/pull/184) @kastiglione
-- fixed command line arguments for test and profile from being overridden [#199](https://github.com/yonaskolb/XcodeGen/pull/199) @vhbit
+- fixed shell scripts escaping quotes twice #186 @allu22
+- fixed `createIntermediateGroups` when using a relative spec path #184 @kastiglione
+- fixed command line arguments for test and profile from being overridden #199 @vhbit
 - fixed files deep within a hierarchy having the path for a name
-- fixed source files from being duplicated if referenced with different casing [#212](https://github.com/yonaskolb/XcodeGen/pull/212) @yonaskolb
-- fixed target product name not being written. Fixes integration with R.swift [#213](https://github.com/yonaskolb/XcodeGen/pull/213) @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.4.0...1.5.0)
+- fixed source files from being duplicated if referenced with different casing #212 @yonaskolb
+- fixed target product name not being written. Fixes integration with R.swift #213 @yonaskolb
 
 ## 1.4.0
 
 #### Added
-- added `--version` flag [#112](https://github.com/yonaskolb/XcodeGen/pull/112) @mironal
-- added support for adding individual file sources [#106](https://github.com/yonaskolb/XcodeGen/pull/106) [#133](https://github.com/yonaskolb/XcodeGen/pull/133) [#142](https://github.com/yonaskolb/XcodeGen/pull/142) [#139](https://github.com/yonaskolb/XcodeGen/pull/139) @bkase
-- added source compiler flag support [#121](https://github.com/yonaskolb/XcodeGen/pull/121) @bkase
-- added `ProjectSpec.options.createIntermediateGroups` [#108](https://github.com/yonaskolb/XcodeGen/pull/108) @bkase
-- added better json loading support [#127](https://github.com/yonaskolb/XcodeGen/pull/127) @rahul-malik
-- added source `name` for customizing names of source directories and file [#146](https://github.com/yonaskolb/XcodeGen/pull/146) @yonaskolb
-- added folder reference source support via a new `type` property [#151](https://github.com/yonaskolb/XcodeGen/pull/151) @yonaskolb
-- added `ProjectSpec.options.developmentLanguage` [#155](https://github.com/yonaskolb/XcodeGen/pull/155) @yonaskolb
+- added `--version` flag #112 @mironal
+- added support for adding individual file sources #106 @bkase
+- added source compiler flag support #121 @bkase
+- added `ProjectSpec.options.createIntermediateGroups` #108 @bkase
+- added better json loading support #127 @rahul-malik
+- added source `name` for customizing names of source directories and file #146 @yonaskolb
+- added folder reference source support via a new `type` property #151 @yonaskolb
+- added `ProjectSpec.options.developmentLanguage` #155 @yonaskolb
 
 #### Changed
-- updated to xcproj 1.2.0 [#113](https://github.com/yonaskolb/XcodeGen/pull/113) @yonaskolb
-- build settings from presets will be removed if they are provided in `xcconfig` files [#77](https://github.com/yonaskolb/XcodeGen/pull/77) @toshi0383
-- all files and groups are sorted by type and then alphabetically [#144](https://github.com/yonaskolb/XcodeGen/pull/144) @yonaskolb
-- target sources can now have an expanded form [#119](https://github.com/yonaskolb/XcodeGen/pull/119) @yonaskolb
-- empty build phases are now not generated [#149](https://github.com/yonaskolb/XcodeGen/pull/149) @yonaskolb
-- make UUIDs more deterministic [#154](https://github.com/yonaskolb/XcodeGen/pull/154) @yonaskolb
+- updated to xcproj 1.2.0 #113 @yonaskolb
+- build settings from presets will be removed if they are provided in `xcconfig` files #77 @toshi0383
+- all files and groups are sorted by type and then alphabetically #144 @yonaskolb
+- target sources can now have an expanded form #119 @yonaskolb
+- empty build phases are now not generated #149 @yonaskolb
+- make UUIDs more deterministic #154 @yonaskolb
 
 #### Fixed
-- only add headers to frameworks and libraries [#118](https://github.com/yonaskolb/XcodeGen/pull/118) @ryohey
-- fixed localized files with the same name [#126](https://github.com/yonaskolb/XcodeGen/pull/126) @ryohey
-- fix intermediate sources [#144](https://github.com/yonaskolb/XcodeGen/pull/144) @yonaskolb
-- fix cyclical target dependencies not working [#147](https://github.com/yonaskolb/XcodeGen/pull/147) @yonaskolb
-- fix directory bundles not being added properly when referenced directly [#148](https://github.com/yonaskolb/XcodeGen/pull/1478) @yonaskolb
-- made `mm`, `c` and `S` file be parsed as source files [#120](https://github.com/yonaskolb/XcodeGen/pull/120) [#125](https://github.com/yonaskolb/XcodeGen/pull/125) [#138](https://github.com/yonaskolb/XcodeGen/pull/138) @bkase @enmiller
-- fix the generation of localized variant groups if there is no `Base.lproj` [#157](https://github.com/yonaskolb/XcodeGen/pull/157) @ryohey
-- all localizations found are added to a projects known regions [#157](https://github.com/yonaskolb/XcodeGen/pull/157) @ryohey
+- only add headers to frameworks and libraries #118 @ryohey
+- fixed localized files with the same name #126 @ryohey
+- fix intermediate sources #144 @yonaskolb
+- fix cyclical target dependencies not working #147 @yonaskolb
+- fix directory bundles not being added properly when referenced directly #148 @yonaskolb
+- made `mm`, `c` and `S` file be parsed as source files #120 @bkase @enmiller
+- fix the generation of localized variant groups if there is no `Base.lproj` #157 @ryohey
+- all localizations found are added to a projects known regions #157 @ryohey
 
 #### Internal
 - refactoring
 - more tests
 - added release scripts
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.3.0...1.4.0)
-
 ## 1.3.0
 
 #### Added
-- generate output files for Carthage copy-frameworks script [#84](https://github.com/yonaskolb/XcodeGen/pull/84) @mironal
-- added options.settingPreset to choose which setting presets get applied [#100](https://github.com/yonaskolb/XcodeGen/pull/101) @yonaskolb
-- added `link` option for target dependencies [#109](https://github.com/yonaskolb/XcodeGen/pull/109) @keith
+- generate output files for Carthage copy-frameworks script #84 @mironal
+- added options.settingPreset to choose which setting presets get applied #100 @yonaskolb
+- added `link` option for target dependencies #109 @keith
 
 #### Changed
-- updated to xcproj 0.4.1 [#85](https://github.com/yonaskolb/XcodeGen/pull/85) @enmiller
-- don't copy base settings if config type has been left out [#100](https://github.com/yonaskolb/XcodeGen/pull/100) @yonaskolb
-- generate localised files under a single variant group [#70](https://github.com/yonaskolb/XcodeGen/pull/70) @ryohey
-- don't apply common project settings to configs with no type [#100](https://github.com/yonaskolb/XcodeGen/pull/100) @yonaskolb
-- config references in settings can now be partially matched and are case insensitive [#111](https://github.com/yonaskolb/XcodeGen/pull/111) @yonaskolb
+- updated to xcproj 0.4.1 #85 @enmiller
+- don't copy base settings if config type has been left out #100 @yonaskolb
+- generate localised files under a single variant group #70 @ryohey
+- don't apply common project settings to configs with no type #100 @yonaskolb
+- config references in settings can now be partially matched and are case insensitive #111 @yonaskolb
 - other small internal changes @yonaskolb
 
 #### Fixed
-- embed Carthage frameworks for macOS [#82](https://github.com/yonaskolb/XcodeGen/pull/82) @toshi0383
-- fixed copying of watchOS app resources [#96](https://github.com/yonaskolb/XcodeGen/pull/96) @keith
-- automatically ignore more file types for a target's sources (entitlements, gpx, apns) [#94](https://github.com/yonaskolb/XcodeGen/pull/94) @keith
-- change make build to a PHONY task [#98](https://github.com/yonaskolb/XcodeGen/pull/98) @keith
-- allow copying of resource files from dependant targets [#95](https://github.com/yonaskolb/XcodeGen/pull/95) @keith
-- fixed library linking [#93](https://github.com/yonaskolb/XcodeGen/pull/93) @keith
-- fixed duplicate carthage file references [#107](https://github.com/yonaskolb/XcodeGen/pull/107) @yonaskolb
+- embed Carthage frameworks for macOS #82 @toshi0383
+- fixed copying of watchOS app resources #96 @keith
+- automatically ignore more file types for a target's sources (entitlements, gpx, apns) #94 @keith
+- change make build to a PHONY task #98 @keith
+- allow copying of resource files from dependant targets #95 @keith
+- fixed library linking #93 @keith
+- fixed duplicate carthage file references #107 @yonaskolb
 - an error is now shown if you try and generate a target scheme and don't have debug and release builds @yonaskolb
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.2.4...1.3.0)
 
 ## 1.2.4
 
@@ -852,17 +794,13 @@ If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project wil
 #### Changed
 - update to xcproj 0.3.0
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.2.3...1.2.4)
-
 ## 1.2.3
 
 #### Fixed
-- Fixed wrong carthage directory name reference for macOS [#74](https://github.com/yonaskolb/XcodeGen/pull/74) @toshi0383
-- Removed unnecessary `carthage copy-frameworks` for macOS app target [#76](https://github.com/yonaskolb/XcodeGen/pull/76) @toshi0383
+- Fixed wrong carthage directory name reference for macOS #74 @toshi0383
+- Removed unnecessary `carthage copy-frameworks` for macOS app target #76 @toshi0383
 - Added some missing default settings for framework targets. `SKIP_INSTALL: YES` fixes archiving
 - Filter out nulls from setting presets if specifying an empty string
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.2.2...1.2.3)
 
 ## 1.2.2
 
@@ -874,26 +812,22 @@ If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project wil
 - fixed tvOS launch screen setting. `ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME` is now `LaunchImage` not `tvOS LaunchImage`
 
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.2.0...1.2.2)
-
 ## 1.2.0
 
 #### Added
 - `include` now supports a single string as well as a list
-- add support setting xcconfig files on a project with `configFiles` [#64](https://github.com/yonaskolb/XcodeGen/pull/64)
-- add `fileGroups` to project spec for adding groups of files that aren't target source files [#64](https://github.com/yonaskolb/XcodeGen/pull/64)
+- add support setting xcconfig files on a project with `configFiles` #64
+- add `fileGroups` to project spec for adding groups of files that aren't target source files #64
 - better output (more info, emoji, colors)
-- add `options.bundleIdPrefix` for autogenerating `PRODUCT_BUNDLE_IDENTIFIER` [#67](https://github.com/yonaskolb/XcodeGen/pull/67)
-- add `:REPLACE` syntax when merging `include` [#68](https://github.com/yonaskolb/XcodeGen/pull/68)
+- add `options.bundleIdPrefix` for autogenerating `PRODUCT_BUNDLE_IDENTIFIER` #67
+- add `:REPLACE` syntax when merging `include` #68
 - add `mint` installation support
 
 #### Fixed
 - fixed homebrew installation
-- fixed target xcconfig files not working via `configFiles` [#64](https://github.com/yonaskolb/XcodeGen/pull/64)
-- look for `INFOPLIST_FILE` setting in project and xcconfig files before adding it automatically. It was just looking in target settings before [#64](https://github.com/yonaskolb/XcodeGen/pull/64)
+- fixed target xcconfig files not working via `configFiles` #64
+- look for `INFOPLIST_FILE` setting in project and xcconfig files before adding it automatically. It was just looking in target settings before #64
 - exit with error on failure
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.1.0...1.2.0)
 
 ## 1.1.0
 
@@ -901,70 +835,58 @@ If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project wil
 - set project version to Xcode 9 - `LastUpgradeVersion` attribute to `0900`
 - set default Swift version to 4.0 - `SWIFT_VERSION` build setting to `4.0`
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.0.1...1.1.0)
-
 ### 1.0.1
 
 ### Fixed
 - fixed incorrect default build script shell path
 - fixed install scripts
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/1.0.0...1.0.1)
-
 ## 1.0.0
 
 #### Added
-- Swift 4 support [#52](https://github.com/yonaskolb/XcodeGen/pull/52)
-- Support for C and C++ files [#48](https://github.com/yonaskolb/XcodeGen/pull/48) by @antoniocasero
+- Swift 4 support #52
+- Support for C and C++ files #48 by @antoniocasero
 - Xcode 9 default settings
 
 #### Fixed
-- fixed empty string in YAML not being parsed properly [#50](https://github.com/yonaskolb/XcodeGen/pull/50) by @antoniocasero
+- fixed empty string in YAML not being parsed properly #50 by @antoniocasero
 
 #### Changed
-- updated to xcodeproj 0.1.2 [#56](https://github.com/yonaskolb/XcodeGen/pull/56)
-- **BREAKING**: changed target definitions from list to map [#54](https://github.com/yonaskolb/XcodeGen/pull/54) See [Project Spec](docs/ProjectSpec.md)
+- updated to xcodeproj 0.1.2 #56
+- **BREAKING**: changed target definitions from list to map #54
 
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.6.1...1.0.0)
 
 ## 0.6.1
 
 #### Added
-- Ability to set PBXProject attributes [#45](https://github.com/yonaskolb/XcodeGen/pull/45)
+- Ability to set PBXProject attributes #45
 
 #### Changed
 - Don't bother linking target frameworks for target dependencies.
-- Move code signing default settings from all iOS targets to iOS application targets, via Product + Platform setting preset files [#46](https://github.com/yonaskolb/XcodeGen/pull/46)
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.6.0...0.6.1)
+- Move code signing default settings from all iOS targets to iOS application targets, via Product + Platform setting preset files #46
 
 ## 0.6.0
 
 #### Added
-- Allow a project spec to include other project specs [#44](https://github.com/yonaskolb/XcodeGen/pull/44)
+- Allow a project spec to include other project specs #44
 
 #### Changed
 - Changed default spec path to `project.yml`
 - Changed default project directory to the current directory instead of the spec file's directory
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.5.1...0.6.0)
 
 ## 0.5.1
 
 #### Fixed
 - Fix embedded framework dependencies
 - Add `CODE_SIGN_IDENTITY[sdk=iphoneos*]` back to iOS targets
-- Fix build scripts with "" generating invalid projects [#43](https://github.com/yonaskolb/XcodeGen/pull/43)
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.5.0...0.5.1)
+- Fix build scripts with "" generating invalid projects #43
 
 ## 0.5.0
 #### Added
-- Added multi platform targets [#35](https://github.com/yonaskolb/XcodeGen/pull/35)
-- Automatically generate platform specific `FRAMEWORK_SEARCH_PATHS` for Carthage dependencies [#38](https://github.com/yonaskolb/XcodeGen/pull/38)
-- Automatically find Info.plist and set `INFOPLIST_FILE` build setting if it doesn't exist on a target [#40](https://github.com/yonaskolb/XcodeGen/pull/40)
-- Add options for controlling embedding of dependencies [#37](https://github.com/yonaskolb/XcodeGen/pull/37)
+- Added multi platform targets #35
+- Automatically generate platform specific `FRAMEWORK_SEARCH_PATHS` for Carthage dependencies #38
+- Automatically find Info.plist and set `INFOPLIST_FILE` build setting if it doesn't exist on a target #40
+- Add options for controlling embedding of dependencies #37
 
 #### Fixed
 - Fixed localized files not being added to a target's resources
@@ -973,28 +895,24 @@ If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project wil
 - Renamed Setting Presets to Setting Groups
 - Carthage group is now created under top level Frameworks group
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.4.0...0.5.0)
-
 ## 0.4.0
 
 ##### Added
-- Homebrew support [#16](https://github.com/yonaskolb/XcodeGen/pull/16) by @pepibumur
-- Added `runOnlyWhenInstalling` to build scripts [#32](https://github.com/yonaskolb/XcodeGen/pull/32)
-- Added `carthageBuildPath` option [#34](https://github.com/yonaskolb/XcodeGen/pull/34)
+- Homebrew support #16 by @pepibumur
+- Added `runOnlyWhenInstalling` to build scripts #32
+- Added `carthageBuildPath` option #34
 
 #### Fixed
 - Fixed installations of XcodeGen not applying build setting presets for configs, products, and platforms, due to missing resources
 
 #### Changed
-- Upgraded to https://github.com/swift-xcode/xcodeproj 0.1.1 [#33](https://github.com/yonaskolb/XcodeGen/pull/33)
-
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.3.0...0.4.0)
+- Upgraded to https://github.com/swift-xcode/xcodeproj 0.1.1 #33
 
 ## 0.3.0 - Extensions and Scheme Tests
 
 #### Added
-- Support for app extension dependencies, using the same `target: MyExtension` syntax [#19](https://github.com/yonaskolb/XcodeGen/pull/19)
-- Added test targets to generated target schemes via `Target.scheme.testTargets` [#21](https://github.com/yonaskolb/XcodeGen/pull/21)
+- Support for app extension dependencies, using the same `target: MyExtension` syntax #19
+- Added test targets to generated target schemes via `Target.scheme.testTargets` #21
 
 #### Changed
 - Updated xcodeproj to 0.0.9
@@ -1005,19 +923,16 @@ If XcodeGen is compiled with Swift 4.2, then UUID's in the generated project wil
 #### Breaking changes
 - Changed `Target.generatedSchemes` to `Target.scheme.configVariants`
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.2...0.3.0)
-
 ## 0.2.0 - Build scripts
 
 #### Added
-- Added Target build scripts with `Target.prebuildScripts` and `Target.postbuildScripts` [#17](https://github.com/yonaskolb/XcodeGen/pull/17)
+- Added Target build scripts with `Target.prebuildScripts` and `Target.postbuildScripts` #17
 - Support for absolute paths in target sources, run script files, and config files
 - Add validation for incorrect `Target.configFiles`
 
 #### Fixed
 - Fixed some project objects sometimes having duplicate ids
 
-[Commits](https://github.com/yonaskolb/XcodeGen/compare/0.1...0.2)
-
 ## 0.1.0
 First official release
+

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -653,6 +653,7 @@ This is a convenience used to automatically generate schemes for a target based 
 - [x] **configVariants**: **[String]** - This generates a scheme for each entry, using configs that contain the name with debug and release variants. This is useful for having different environment schemes.
 - [ ] **testTargets**: **[[Test Target](#test-target)]** - a list of test targets that should be included in the scheme. These will be added to the build targets and the test entries. Each entry can either be a simple string, or a [Test Target](#test-target)
 - [ ] **gatherCoverageData**: **Bool** - a boolean that indicates if this scheme should gather coverage data. This defaults to false
+- [ ] **coverageTargets**: **[[Testable Target Reference](#testable-target-reference) - a list of targets to gather code coverage. Each entry can either be a simple string, a string using [Project Reference](#project-reference) or [Testable Target Reference](#testable-target-reference)
 - [ ] **disableMainThreadChecker**: **Bool** - a boolean that indicates if this scheme should disable the Main Thread Checker. This defaults to false
 - [ ] **stopOnEveryMainThreadCheckerIssue**: **Bool** - a boolean that indicates if this scheme should stop at every Main Thread Checker issue. This defaults to false
 - [ ] **buildImplicitDependencies**: **Bool** - Flag to determine if Xcode should build implicit dependencies of this scheme. By default this is `true` if not set.
@@ -691,6 +692,9 @@ targets:
         - Staging
         - Production
       gatherCoverageData: true
+      coverageTargets:
+        - MyTarget1
+        - ExternalTarget/OtherTarget1
       commandLineArguments:
         "-MyEnabledArg": true
         "-MyDisabledArg": false
@@ -824,20 +828,34 @@ A multiline script can be written using the various YAML multiline methods, for 
 ### Test Action
 
 - [ ] **gatherCoverageData**: **Bool** - a boolean that indicates if this scheme should gather coverage data. This defaults to false
-- [ ] **coverageTargets**: **[String]** - a list of targets to gather code coverage. Each entry can either be a simple string, or a string using [Project Reference](#project-reference)
+- [ ] **coverageTargets**: **[[Testable Target Reference](#testable-target-reference)]** - a list of targets to gather code coverage. Each entry can either be a simple string, a string using [Project Reference](#project-reference) or [Testable Target Reference](#testable-target-reference)
 - [ ] **targets**: **[[Test Target](#test-target)]** - a list of targets to test. Each entry can either be a simple string, or a [Test Target](#test-target)
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
 - [ ] **captureScreenshotsAutomatically**: **Bool** - indicates whether screenshots should be captured automatically while UI Testing. This defaults to true.
 - [ ] **deleteScreenshotsWhenEachTestSucceeds**: **Bool** - whether successful UI tests should cause automatically-captured screenshots to be deleted. If `captureScreenshotsAutomatically` is false, this value is ignored. This defaults to true.
 
 #### Test Target
-- [x] **name**: **String** - The name of the target
+A target can be one of a 2 types:
+
+- **name**: **String** - The name of the target.
+- **target**: **[Testable Target Reference](#testable-target-reference)** - The information of the target. You can specify more detailed information than `name:`.
+
+As syntax suger, you can also specify **[Testable Target Reference](#testable-target-reference)** without `target`.
+
+#### Other Parameters
+
 - [ ] **parallelizable**: **Bool** - Whether to run tests in parallel. Defaults to false
 - [ ] **randomExecutionOrder**: **Bool** - Whether to run tests in a random order. Defaults to false
 - [ ] **location**: **String** - GPX file or predefined value for simulating location. See [Simulate Location](#simulate-location) for location examples.
 - [ ] **skipped**: **Bool** - Whether to skip all of the test target tests. Defaults to false
 - [ ] **skippedTests**: **[String]** - List of tests in the test target to skip. Defaults to empty
 - [ ] **selectedTests**: **[String]** - List of tests in the test target to whitelist and select. Defaults to empty. This will override `skippedTests` if provided
+
+#### Testable Target Reference
+A Testable Target Reference can be one of 3 types:
+- `package: {local-swift-package-name}/{target-name}`: Name of local swift package and its target.
+- `local: {target-name}`:  Name of local target.
+- `project: {project-reference-name}/{target-name}`:  Name of local swift package and its target.
 
 ### Archive Action
 
@@ -898,12 +916,16 @@ schemes:
       coverageTargets:
         - MyTarget1
         - ExternalTarget/OtherTarget1
+        - package: LocalPackage/TestTarget
       targets: 
         - Tester1 
         - name: Tester2
           parallelizable: true
           randomExecutionOrder: true
           skippedTests: [Test/testExample()]
+        - package: APIClient/APIClientTests
+          parallelizable: true
+          randomExecutionOrder: true
       environmentVariables:
         - variable: TEST_ENV_VAR
           value: VALUE
@@ -971,6 +993,7 @@ Swift packages are defined at a project level, and then linked to individual tar
 ### Local Package
 
 - [x] **path**: **String** - the path to the package in local. The path must be directory with a `Package.swift`.
+- [ ] **group** : **String**- Optional path that specifies the location where the package will live in your xcode project.
 
 ```yml
 packages:
@@ -982,6 +1005,9 @@ packages:
     from: 0.5.0
   RxClient:
     path: ../RxClient
+  AppFeature:
+    path: ../Packages
+    group: Domains/AppFeature
 ```
 
 ## Project Reference

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOOL_NAME = XcodeGen
 export EXECUTABLE_NAME = xcodegen
-VERSION = 2.26.0
+VERSION = 2.28.0
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(EXECUTABLE_NAME)

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,9 +32,18 @@
         "package": "PathKit",
         "repositoryURL": "https://github.com/michaeleisel/PathKit.git",
         "state": {
-          "branch": null,
-          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-          "version": "1.0.1"
+          "branch": "me-fast",
+          "revision": "a2e1212c4c7fd333e84539b7f7e92a42df6f0893",
+          "version": null
+        }
+      },
+      {
+        "package": "PathKitCExt",
+        "repositoryURL": "https://github.com/michaeleisel/PathKitCExt.git",
+        "state": {
+          "branch": "master",
+          "revision": "fddd173ba9f67d97363e2631b444b4a7eb2f1cf6",
+          "version": null
         }
       },
       {
@@ -50,9 +59,9 @@
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
-          "branch": null,
+          "branch": "master",
           "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
-          "version": "0.10.1"
+          "version": null
         }
       },
       {

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ swift run xcodegen
 Add the following to your Package.swift file's dependencies:
 
 ```swift
-.package(url: "https://github.com/yonaskolb/XcodeGen.git", from: "2.26.0"),
+.package(url: "https://github.com/yonaskolb/XcodeGen.git", from: "2.28.0"),
 ```
 
 And then import wherever needed: `import XcodeGenKit`

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -75,6 +75,7 @@ extension FileType {
 
         // sources
         "swift": FileType(buildPhase: .sources),
+        "gyb": FileType(buildPhase: .sources),
         "m": FileType(buildPhase: .sources),
         "mm": FileType(buildPhase: .sources),
         "cpp": FileType(buildPhase: .sources),
@@ -88,6 +89,7 @@ extension FileType {
         "mlmodel": FileType(buildPhase: .sources),
         "rcproject": FileType(buildPhase: .sources),
         "iig": FileType(buildPhase: .sources),
+        "docc": FileType(buildPhase: .sources),
 
         // headers
         "h": FileType(buildPhase: .headers),
@@ -112,6 +114,5 @@ extension FileType {
         "xcfilelist": FileType(buildPhase: BuildPhaseSpec.none),
         "apns": FileType(buildPhase: BuildPhaseSpec.none),
         "pch": FileType(buildPhase: BuildPhaseSpec.none),
-        "docc": FileType(buildPhase: BuildPhaseSpec.none),
     ]
 }

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -83,6 +83,10 @@ public struct Project: BuildSettingsContainer {
         targetsMap[targetName]
     }
 
+    public func getPackage(_ packageName: String) -> SwiftPackage? {
+        packages[packageName]
+    }
+
     public func getAggregateTarget(_ targetName: String) -> AggregateTarget? {
         aggregateTargetsMap[targetName]
     }
@@ -189,7 +193,7 @@ extension Project {
             packages.merge(localPackages.reduce(into: [String: SwiftPackage]()) {
                 // Project name will be obtained by resolved abstractpath's lastComponent for dealing with some path case, like "../"
                 let packageName = (basePath + Path($1).normalize()).lastComponent
-                $0[packageName] = .local(path: $1)
+                $0[packageName] = .local(path: $1, group: nil)
             }
             )
         }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -54,7 +54,7 @@ extension Project {
         }
 
         for (name, package) in packages {
-            if case let .local(path) = package, !(basePath + Path(path).normalize()).exists {
+            if case let .local(path, _) = package, !(basePath + Path(path).normalize()).exists {
                 errors.append(.invalidLocalPackage(name))
             }
         }
@@ -119,6 +119,10 @@ extension Project {
 
                 for testTarget in scheme.testTargets {
                     if getTarget(testTarget.name) == nil {
+                        // For test case of local Swift Package
+                        if case .package(let name) = testTarget.targetReference.location, getPackage(name) != nil {
+                            continue
+                        }
                         errors.append(.invalidTargetSchemeTest(target: target.name, testTarget: testTarget.name))
                     }
                 }
@@ -240,6 +244,20 @@ extension Project {
         case .project(let project) where getProjectReference(project) == nil:
             return .invalidProjectReference(scheme: scheme.name, reference: project)
         case .local, .project:
+            return nil
+        }
+    }
+    
+    /// Returns a descriptive error if the given target reference was invalid otherwise `nil`.
+    private func validationError(for testableTargetReference: TestableTargetReference, in scheme: Scheme, action: String) -> SpecValidationError.ValidationError? {
+        switch testableTargetReference.location {
+        case .local where getProjectTarget(testableTargetReference.name) == nil:
+            return .invalidSchemeTarget(scheme: scheme.name, target: testableTargetReference.name, action: action)
+        case .project(let project) where getProjectReference(project) == nil:
+            return .invalidProjectReference(scheme: scheme.name, reference: project)
+        case .package(let package) where getPackage(package) == nil:
+            return .invalidLocalPackage(package)
+        case .local, .project, .package:
             return nil
         }
     }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -20,6 +20,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidSchemeTarget(scheme: String, target: String, action: String)
         case invalidSchemeConfig(scheme: String, config: String)
         case invalidSwiftPackage(name: String, target: String)
+        case invalidPackageDependencyReference(name: String)
         case invalidLocalPackage(String)
         case invalidConfigFile(configFile: String, config: String)
         case invalidBuildSettingConfig(String)
@@ -69,6 +70,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Target \(target.quoted) has an invalid package dependency \(name.quoted)"
             case let .invalidLocalPackage(path):
                 return "Invalid local package \(path.quoted)"
+            case let .invalidPackageDependencyReference(name):
+                return "Package reference \(name) must be specified as package dependency, not target"
             case let .missingConfigForTargetScheme(target, configType):
                 return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
             case let .missingDefaultConfig(name):

--- a/Sources/ProjectSpec/SwiftPackage.swift
+++ b/Sources/ProjectSpec/SwiftPackage.swift
@@ -10,7 +10,7 @@ public enum SwiftPackage: Equatable {
     static let githubPrefix = "https://github.com/"
 
     case remote(url: String, versionRequirement: VersionRequirement)
-    case local(path: String)
+    case local(path: String, group: String?)
 
     public var isLocal: Bool {
         if case .local = self {
@@ -23,8 +23,10 @@ public enum SwiftPackage: Equatable {
 extension SwiftPackage: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        if let path: String = jsonDictionary.json(atKeyPath: "path") {
-            self = .local(path: path)
+        if let path: String = jsonDictionary.json(atKeyPath: "path"), let customLocation: String = jsonDictionary.json(atKeyPath: "group") {
+            self = .local(path: path, group: customLocation)
+        } else if let path: String = jsonDictionary.json(atKeyPath: "path") {
+            self = .local(path: path, group: nil)
         } else {
             let versionRequirement: VersionRequirement = try VersionRequirement(jsonDictionary: jsonDictionary)
             try Self.validateVersion(versionRequirement: versionRequirement)
@@ -90,8 +92,9 @@ extension SwiftPackage: JSONEncodable {
                 dictionary["revision"] = revision
             }
             return dictionary
-        case .local(let path):
+        case let .local(path, group):
             dictionary["path"] = path
+            dictionary["group"] = group
         }
 
         return dictionary

--- a/Sources/ProjectSpec/TargetReference.swift
+++ b/Sources/ProjectSpec/TargetReference.swift
@@ -46,8 +46,8 @@ extension TargetReference: CustomStringConvertible {
     public var reference: String {
         switch location {
         case .local: return name
-        case .project(let projectPath):
-            return "\(projectPath)/\(name)"
+        case .project(let root):
+            return "\(root)/\(name)"
         }
     }
 

--- a/Sources/ProjectSpec/TestTargeReference.swift
+++ b/Sources/ProjectSpec/TestTargeReference.swift
@@ -1,0 +1,112 @@
+import Foundation
+import JSONUtilities
+
+public struct TestableTargetReference: Hashable {
+    public var name: String
+    public var location: Location
+    
+    public var targetReference: TargetReference {
+        switch location {
+        case .local:
+            return TargetReference(name: name, location: .local)
+        case .project(let projectName):
+            return TargetReference(name: name, location: .project(projectName))
+        case .package:
+            fatalError("Package target is only available for testable")
+        }
+    }
+
+    public enum Location: Hashable {
+        case local
+        case project(String)
+        case package(String)
+    }
+
+    public init(name: String, location: Location) {
+        self.name = name
+        self.location = location
+    }
+}
+
+extension TestableTargetReference {
+    public init(_ string: String) throws {
+        let paths = string.split(separator: "/")
+        switch paths.count {
+        case 2:
+            location = .project(String(paths[0]))
+            name = String(paths[1])
+        case 1:
+            location = .local
+            name = String(paths[0])
+        default:
+            throw SpecParsingError.invalidTargetReference(string)
+        }
+    }
+
+    public static func local(_ name: String) -> TestableTargetReference {
+        TestableTargetReference(name: name, location: .local)
+    }
+
+    public static func project(_ name: String) -> TestableTargetReference {
+        let paths = name.split(separator: "/")
+        return TestableTargetReference(name: String(paths[1]), location: .project(String(paths[0])))
+    }
+
+    public static func package(_ name: String) -> TestableTargetReference {
+        let paths = name.split(separator: "/")
+        return TestableTargetReference(name: String(paths[1]), location: .package(String(paths[0])))
+    }
+}
+
+extension TestableTargetReference: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        try! self.init(value)
+    }
+}
+
+extension TestableTargetReference: CustomStringConvertible {
+    public var reference: String {
+        switch location {
+        case .local: return name
+        case .project(let root), .package(let root):
+            return "\(root)/\(name)"
+        }
+    }
+
+    public var description: String {
+        reference
+    }
+}
+
+extension TestableTargetReference: JSONObjectConvertible {
+
+    public init(jsonDictionary: JSONDictionary) throws {
+        if let project: String = jsonDictionary.json(atKeyPath: "project") {
+            let paths = project.split(separator: "/")
+            name = String(paths[1])
+            location = .project(String(paths[0]))
+        } else if let project: String = jsonDictionary.json(atKeyPath: "package") {
+            let paths = project.split(separator: "/")
+            name = String(paths[1])
+            location = .package(String(paths[0]))
+        } else {
+            name = try jsonDictionary.json(atKeyPath: "local")
+            location = .local
+        }
+    }
+}
+
+extension TestableTargetReference: JSONEncodable {
+    public func toJSONValue() -> Any {
+        var dictionary: JSONDictionary = [:]
+        switch self.location {
+        case .package(let packageName):
+            dictionary["package"] = "\(packageName)/\(name)"
+        case .project(let projectName):
+            dictionary["project"] = "\(projectName)/\(name)"
+        case .local:
+            dictionary["local"] = name
+        }
+        return dictionary
+    }
+}

--- a/Sources/ProjectSpec/XCProjExtensions.swift
+++ b/Sources/ProjectSpec/XCProjExtensions.swift
@@ -48,8 +48,8 @@ extension PBXProductType {
 
     public var canSkipCompileSourcesBuildPhase: Bool {
         switch self {
-        case .bundle, .stickerPack, .messagesApplication:
-            // Bundles, sticker packs and simple messages applications without sources should not include a
+        case .bundle, .watch2App, .stickerPack, .messagesApplication:
+            // Bundles, watch apps, sticker packs and simple messages applications without sources should not include a
             // compile sources build phase. Doing so can cause Xcode to produce an error on build.
             return true
         default:

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -3,6 +3,6 @@ import ProjectSpec
 import XcodeGenCLI
 import Version
 
-let version = Version("2.26.0")
+let version = Version("2.28.0")
 let cli = XcodeGenCLI(version: version)
 cli.execute()

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -28,9 +28,9 @@ class ProjectCommand: Command {
     }
 
     func execute() throws {
-
+        
         let projectSpecPath = (spec ?? "project.yml").absolute()
-
+        
         if !projectSpecPath.exists {
             throw GenerationError.missingProjectSpec(projectSpecPath)
         }

--- a/Sources/XcodeGenCore/Atomic.swift
+++ b/Sources/XcodeGenCore/Atomic.swift
@@ -1,0 +1,52 @@
+//
+//  Atomic.swift
+//  
+//
+//  Created by Vladislav Lisianskii on 23.02.2022.
+//
+
+import Foundation
+
+@propertyWrapper
+public final class Atomic<Value> {
+
+    private var value: Value
+
+    private let queue = DispatchQueue(
+        label: "com.xcodegencore.atomic.\(UUID().uuidString)",
+        qos: .utility,
+        attributes: .concurrent,
+        autoreleaseFrequency: .inherit,
+        target: .global()
+    )
+
+    public init(wrappedValue: Value) {
+        self.value = wrappedValue
+    }
+
+    public var wrappedValue: Value {
+        get {
+            queue.sync { value }
+        }
+        set {
+            queue.async(flags: .barrier) { [weak self] in
+                self?.value = newValue
+            }
+        }
+    }
+
+    /// Allows us to get the actual `Atomic` instance with the $
+    /// prefix.
+    public var projectedValue: Atomic<Value> {
+        return self
+    }
+
+    /// Modifies the protected value using `closure`.
+    public func with<R>(
+        _ closure: (inout Value) throws -> R
+    ) rethrows -> R {
+        try queue.sync(flags: .barrier) {
+            try closure(&value)
+        }
+    }
+}

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -168,8 +168,8 @@ public class PBXProjGenerator {
                 let packageReference = XCRemoteSwiftPackageReference(repositoryURL: url, versionRequirement: versionRequirement)
                 packageReferences[name] = packageReference
                 addObject(packageReference)
-            case let .local(path):
-                try sourceGenerator.createLocalPackage(path: Path(path))
+            case let .local(path, group):
+                try sourceGenerator.createLocalPackage(path: Path(path), group: group.map { Path($0) })
             }
         }
 
@@ -1153,7 +1153,7 @@ public class PBXProjGenerator {
                     name: "Carthage",
                     inputPaths: inputPaths,
                     outputPaths: outputPaths,
-                    shellPath: "/bin/sh",
+                    shellPath: "/bin/sh -l",
                     shellScript: "\(carthageExecutable) copy-frameworks\n"
                 )
             )

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -136,9 +136,27 @@ public class SchemeGenerator {
                 blueprintName: target.name
             )
         }
+        
+        func getBuildableTestableReference(_ target: TestableTargetReference) throws -> XCScheme.BuildableReference {
+            switch target.location {
+            case .package(let packageName):
+                guard let package = self.project.getPackage(packageName),
+                      case let .local(path, _) = package else {
+                    throw SchemeGenerationError.missingPackage(packageName)
+                }
+                return XCScheme.BuildableReference(
+                    referencedContainer: "container:\(path)",
+                    blueprintIdentifier: target.name,
+                    buildableName: target.name,
+                    blueprintName: target.name
+                )
+            default:
+                return try getBuildableReference(target.targetReference)
+            }
+        }
 
         func getBuildEntry(_ buildTarget: Scheme.BuildTarget) throws -> XCScheme.BuildAction.Entry {
-            let buildableReference = try getBuildableReference(buildTarget.target)
+            let buildableReference = try getBuildableTestableReference(buildTarget.target)
             return XCScheme.BuildAction.Entry(buildableReference: buildableReference, buildFor: buildTarget.buildTypes)
         }
 
@@ -216,7 +234,7 @@ public class SchemeGenerator {
         }
 
         let coverageBuildableTargets = try scheme.test?.coverageTargets.map {
-            try getBuildableReference($0)
+            try getBuildableTestableReference($0)
         } ?? []
 
         let testCommandLineArgs = scheme.test.map { XCScheme.CommandLineArguments($0.commandLineArguments) }
@@ -375,6 +393,7 @@ public class SchemeGenerator {
 enum SchemeGenerationError: Error, CustomStringConvertible {
 
     case missingTarget(TargetReference, projectPath: String)
+    case missingPackage(String)
     case missingProject(String)
     case missingBuildTargets(String)
 
@@ -386,6 +405,8 @@ enum SchemeGenerationError: Error, CustomStringConvertible {
             return "Unable to find project reference named \"\(project)\" in project.yml"
         case .missingBuildTargets(let name):
             return "Unable to find at least one build target in scheme \"\(name)\""
+        case .missingPackage(let package):
+            return "Unable to find swift package named \"\(package)\" in project.yml"
         }
     }
 }
@@ -413,6 +434,7 @@ extension Scheme {
             test: .init(
                 config: debugConfig,
                 gatherCoverageData: targetScheme.gatherCoverageData,
+                coverageTargets: targetScheme.coverageTargets,
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker,
                 commandLineArguments: targetScheme.commandLineArguments,
                 targets: targetScheme.testTargets,
@@ -435,14 +457,14 @@ extension Scheme {
     }
 
     private static func buildTargets(for target: Target, project: Project) -> [BuildTarget] {
-        let buildTarget = Scheme.BuildTarget(target: TargetReference.local(target.name))
+        let buildTarget = Scheme.BuildTarget(target: TestableTargetReference.local(target.name))
         switch target.type {
         case .watchApp, .watch2App:
             let hostTarget = project.targets
                 .first { projectTarget in
                     projectTarget.dependencies.contains { $0.reference == target.name }
                 }
-                .map { BuildTarget(target: TargetReference.local($0.name)) }
+                .map { BuildTarget(target: TestableTargetReference.local($0.name)) }
             return hostTarget.map { [buildTarget, $0] } ?? [buildTarget]
         default:
             return [buildTarget]

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -53,16 +53,22 @@ class SourceGenerator {
         return object
     }
 
-    func createLocalPackage(path: Path) throws {
-
-        if localPackageGroup == nil {
+    func createLocalPackage(path: Path, group: Path?) throws {
+        var pbxGroup: PBXGroup?
+        
+        if let location = group {
+            let fullLocationPath = project.basePath + location
+            pbxGroup = getGroup(path: fullLocationPath, mergingChildren: [], createIntermediateGroups: true, hasCustomParent: false, isBaseGroup: true)
+        }
+        
+        if localPackageGroup == nil && group == nil {
             let groupName = project.options.localPackagesGroup ?? "Packages"
             localPackageGroup = addObject(PBXGroup(sourceTree: .sourceRoot, name: groupName))
             rootGroups.insert(localPackageGroup!)
         }
-
+        
         let absolutePath = project.basePath + path.normalize()
-
+        
         // Get the local package's relative path from the project root
         let fileReferencePath = try? absolutePath.relativePath(from: projectDirectory ?? project.basePath).string
 
@@ -74,7 +80,11 @@ class SourceGenerator {
                 path: fileReferencePath
             )
         )
-        localPackageGroup!.children.append(fileReference)
+        if let pbxGroup = pbxGroup {
+            pbxGroup.children.append(fileReference)
+        } else {
+            localPackageGroup!.children.append(fileReference)
+        }
     }
 
     /// Collects an array complete of all `SourceFile` objects that make up the target based on the provided `TargetSource` definitions.
@@ -358,7 +368,7 @@ class SourceGenerator {
             return cachedResult
         }
         let result = Set(
-            Array(patterns.map { pattern -> [Path] in
+            Array(patterns.parallelMap { pattern -> [Path] in
                 guard !pattern.isEmpty else { return [] }
                 return Array(Glob(pattern: "\(rootSourcePath)/\(pattern)")
                     .map { Path($0) }

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		23C6626698DE560017A89F2F /* XcodeGen in Frameworks */ = {isa = PBXBuildFile; productRef = 6F7DEA2D82649EDF903FBDBD /* XcodeGen */; };
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
 		3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; };
 		4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */; };
@@ -58,8 +59,8 @@
 		61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
 		7970A2253B14A9B27C307FAC /* SPMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPMTests.swift; sourceTree = "<group>"; };
 		A9601593D0AD02931266A4E5 /* App.xctestplan */ = {isa = PBXFileReference; path = App.xctestplan; sourceTree = "<group>"; };
-		C1DE9A872F470EAA65B9B0B0 /* XcodeGen */ = {isa = PBXFileReference; lastKnownFileType = folder; name = XcodeGen; path = ../../..; sourceTree = SOURCE_ROOT; };
 		CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		ED284AB7C13DCC0A95DAA680 /* XcodeGen */ = {isa = PBXFileReference; lastKnownFileType = folder; name = XcodeGen; path = ../../..; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +71,7 @@
 				CE46CBA5671B951B546C8673 /* Codability in Frameworks */,
 				3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */,
 				4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */,
+				23C6626698DE560017A89F2F /* XcodeGen in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,6 +85,7 @@
 				26F7EFEE613987D1E1258A60 /* AppDelegate.swift */,
 				4E22B8BCC18A29EFE1DE3BE4 /* Assets.xcassets */,
 				464ACF8D8F2D9F219BCFD3E7 /* Info.plist */,
+				ED284AB7C13DCC0A95DAA680 /* XcodeGen */,
 			);
 			path = SPM;
 			sourceTree = "<group>";
@@ -98,7 +101,6 @@
 		218F6C96DF9E182F526258CF = {
 			isa = PBXGroup;
 			children = (
-				AD0F3623091EEA8D1EA3DFF8 /* Packages */,
 				17DD374CC81D710476AFF41C /* SPM */,
 				CF3BD77AEAA56553289456BA /* SPMTests */,
 				1FA59BFD192FB5A68D5F587C /* StaticLibrary */,
@@ -115,14 +117,6 @@
 			);
 			name = Products;
 			sourceTree = "<group>";
-		};
-		AD0F3623091EEA8D1EA3DFF8 /* Packages */ = {
-			isa = PBXGroup;
-			children = (
-				C1DE9A872F470EAA65B9B0B0 /* XcodeGen */,
-			);
-			name = Packages;
-			sourceTree = SOURCE_ROOT;
 		};
 		CF3BD77AEAA56553289456BA /* SPMTests */ = {
 			isa = PBXGroup;
@@ -193,6 +187,7 @@
 			packageProductDependencies = (
 				16E6FE01D5BD99F78D4A17E2 /* Codability */,
 				DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */,
+				6F7DEA2D82649EDF903FBDBD /* XcodeGen */,
 			);
 			productName = App;
 			productReference = 097F2DB5622B591E21BC3C73 /* App.app */;
@@ -593,6 +588,10 @@
 			productName = Codability;
 		};
 		5A36E2FE69703FCAC0BE8064 /* XcodeGen */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XcodeGen;
+		};
+		6F7DEA2D82649EDF903FBDBD /* XcodeGen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeGen;
 		};

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -30,6 +30,26 @@
       onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XcodeGenKitTests"
+               BuildableName = "XcodeGenKitTests"
+               BlueprintName = "XcodeGenKitTests"
+               ReferencedContainer = "container:../../..">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "339863E54E2D955C00B56802"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:SPM.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Tests/Fixtures/SPM/project.yml
+++ b/Tests/Fixtures/SPM/project.yml
@@ -6,14 +6,18 @@ packages:
   SwiftRoaring:
     url: https://github.com/piotte13/SwiftRoaring
     majorVersion: 1.0.4
-  XcodeGen: 
+  XcodeGen:
     path: ../../.. #XcodeGen itself
+    group: SPM
 targets:
   App:
     type: application
     platform: iOS
     sources: [SPM]
-    scheme: {}
+    scheme:
+      testTargets:
+        - package: XcodeGen/XcodeGenKitTests
+        - Tests
     dependencies:
       - package: Codability
         weak: true
@@ -21,6 +25,7 @@ targets:
         product: SwiftRoaringDynamic
         embed: true
       - target: StaticLibrary
+      - package: XcodeGen
   Tests:
     type: bundle.unit-test
     platform: iOS

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1E03FC7312293997599C6435 /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 068EDF47F0B087F6A4052AC0 /* Empty.h */; };
 		1E2A4D61E96521FF7123D7B0 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E457F55331FD2C3E8E00BE2 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1F9168A43FD8E2FCC2699E14 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = B5C943D39DD7812CAB94B614 /* Documentation.docc */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		210B49C23B9717C668B40C8C /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		2116F89CF5A04EA0EFA30A89 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D88C6BF7355702B74396791 /* TestProjectUITests.swift */; };
 		212BCB51DAF3212993DDD49E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D51CC8BCCBD68A90E90A3207 /* Assets.xcassets */; };
@@ -1697,7 +1698,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6B5C5F08C0EF06457756E379 /* Build configuration list for PBXNativeTarget "App_watchOS" */;
 			buildPhases = (
-				91C895DE8170C96A75D29426 /* Sources */,
 				B7B71FA7D279029BF7A7FC7C /* Resources */,
 				C765431E5FF4B02F59DE79B0 /* Embed App Extensions */,
 			);
@@ -2384,7 +2384,7 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
+			shellPath = "/bin/sh -l";
 			shellScript = "carthage copy-frameworks\n";
 		};
 		3D0637F4554EAD6FA48105BF /* MyScript */ = {
@@ -2473,7 +2473,7 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
+			shellPath = "/bin/sh -l";
 			shellScript = "carthage copy-frameworks\n";
 		};
 		BA454AAC926EDFCDA9226CBC /* MyScript */ = {
@@ -2546,7 +2546,7 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
+			shellPath = "/bin/sh -l";
 			shellScript = "carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -2656,6 +2656,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09617AB755651FFEB2564CBC /* AppDelegate.swift in Sources */,
+				1F9168A43FD8E2FCC2699E14 /* Documentation.docc in Sources */,
 				666DEC173BC78C7641AB22EC /* File1.swift in Sources */,
 				339578307B9266AB3D7722D9 /* File2.swift in Sources */,
 				F788A3FA1CE6489BC257C1C3 /* Model.xcdatamodeld in Sources */,
@@ -2703,13 +2704,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D80BD5FAE6BE61CFD74CF1B /* FrameworkFile.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		91C895DE8170C96A75D29426 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -28,7 +28,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO"
       disableMainThreadChecker = "YES">
       <Testables>
@@ -72,6 +72,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F7"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Production Debug"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -28,7 +28,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO"
       disableMainThreadChecker = "YES">
       <Testables>
@@ -72,6 +72,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F7"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Staging Debug"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -28,7 +28,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO"
       disableMainThreadChecker = "YES">
       <Testables>
@@ -72,6 +72,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F7"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Test Debug"

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -152,6 +152,8 @@ targets:
         - App_iOS_Tests
         - App_iOS_UITests
       gatherCoverageData: true
+      coverageTargets:
+        - App_iOS
       disableMainThreadChecker: true
       stopOnEveryMainThreadCheckerIssue: true
       configVariants:

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -126,7 +126,7 @@ class ProjectSpecTests: XCTestCase {
                 project.settings = invalidSettings
                 project.configFiles = ["invalidConfig": "invalidConfigFile"]
                 project.fileGroups = ["invalidFileGroup"]
-                project.packages = ["invalidLocalPackage": .local(path: "invalidLocalPackage")]
+                project.packages = ["invalidLocalPackage": .local(path: "invalidLocalPackage", group: nil)]
                 project.settingGroups = ["settingGroup1": Settings(
                     configSettings: ["invalidSettingGroupConfig": [:]],
                     groups: ["invalidSettingGroupSettingGroup"]
@@ -463,6 +463,7 @@ class ProjectSpecTests: XCTestCase {
                                                                                                               parallelizable: false)],
                                                                          configVariants: ["foo"],
                                                                          gatherCoverageData: true,
+                                                                         coverageTargets: ["App"],
                                                                          storeKitConfiguration: "Configuration.storekit",
                                                                          disableMainThreadChecker: true,
                                                                          stopOnEveryMainThreadCheckerIssue: false,

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -712,6 +712,7 @@ class SpecLoadingTests: XCTestCase {
                         "ENV1": true,
                     ],
                     "gatherCoverageData": true,
+                    "coverageTargets": ["t1"],
                     "storeKitConfiguration": "Configuration.storekit",
                     "language": "en",
                     "region": "US",
@@ -740,6 +741,7 @@ class SpecLoadingTests: XCTestCase {
                     testTargets: ["t1", "t2"],
                     configVariants: ["dev", "app-store"],
                     gatherCoverageData: true,
+                    coverageTargets: ["t1"],
                     storeKitConfiguration: "Configuration.storekit",
                     language: "en",
                     region: "US",
@@ -1225,9 +1227,10 @@ class SpecLoadingTests: XCTestCase {
                     "package6": .remote(url: "package.git", versionRequirement: .range(from: "1.2.0", to: "1.2.5")),
                     "package7": .remote(url: "package.git", versionRequirement: .exact("1.2.2")),
                     "package8": .remote(url: "package.git", versionRequirement: .upToNextMajorVersion("4.0.0-beta.5")),
-                    "package9": .local(path: "package/package"),
+                    "package9": .local(path: "package/package", group: nil),
                     "package10": .remote(url: "https://github.com/yonaskolb/XcodeGen", versionRequirement: .exact("1.2.2")),
-                    "XcodeGen": .local(path: "../XcodeGen"),
+                    "XcodeGen": .local(path: "../XcodeGen", group: nil),
+                    "package11": .local(path: "../XcodeGen", group: "Packages/Feature"),
                 ], options: .init(localPackagesGroup: "MyPackages"))
 
                 let dictionary: [String: Any] = [
@@ -1246,6 +1249,7 @@ class SpecLoadingTests: XCTestCase {
                         "package8": ["url": "package.git", "majorVersion": "4.0.0-beta.5"],
                         "package9": ["path": "package/package"],
                         "package10": ["github": "yonaskolb/XcodeGen", "exactVersion": "1.2.2"],
+                        "package11": ["path": "../XcodeGen", "group": "Packages/Feature"],
                     ],
                     "localPackages": ["../XcodeGen"],
                 ]
@@ -1255,8 +1259,8 @@ class SpecLoadingTests: XCTestCase {
 
             $0.it("parses old local package format") {
                 let project = Project(name: "spm", packages: [
-                    "XcodeGen": .local(path: "../XcodeGen"),
-                    "Yams": .local(path: "Yams"),
+                    "XcodeGen": .local(path: "../XcodeGen", group: nil),
+                    "Yams": .local(path: "Yams", group: nil),
                 ], options: .init(localPackagesGroup: "MyPackages"))
 
                 let dictionary: [String: Any] = [

--- a/Tests/XcodeGenCoreTests/AtomicTests.swift
+++ b/Tests/XcodeGenCoreTests/AtomicTests.swift
@@ -1,0 +1,39 @@
+//
+//  AtomicTests.swift
+//  
+//
+//  Created by Vladislav Lisianskii on 27.03.2022.
+//
+
+import XCTest
+@testable import XcodeGenCore
+
+final class AtomicTests: XCTestCase {
+
+    @Atomic private var atomicDictionary = [String: Int]()
+
+    func testSimultaneousWriteOrder() {
+        let group = DispatchGroup()
+
+        for index in (0..<100) {
+            group.enter()
+            DispatchQueue.global().async {
+                self.$atomicDictionary.with { atomicDictionary in
+                    atomicDictionary["\(index)"] = index
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main, execute: {
+            var expectedValue = [String: Int]()
+            for index in (0..<100) {
+                expectedValue["\(index)"] = index
+            }
+            XCTAssertEqual(
+                self.atomicDictionary,
+                expectedValue
+            )
+        })
+    }
+}

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1271,7 +1271,7 @@ class ProjectGeneratorTests: XCTestCase {
                 let project = Project(name: "test", targets: [app], packages: [
                     "XcodeGen": .remote(url: "http://github.com/yonaskolb/XcodeGen", versionRequirement: .branch("master")),
                     "Codability": .remote(url: "http://github.com/yonaskolb/Codability", versionRequirement: .exact("1.0.0")),
-                    "Yams": .local(path: "../Yams"),
+                    "Yams": .local(path: "../Yams", group: nil),
                 ], options: .init(localPackagesGroup: "MyPackages"))
 
                 let pbxProject = try project.generatePbxProj(specValidate: false)
@@ -1304,7 +1304,38 @@ class ProjectGeneratorTests: XCTestCase {
                     ]
                 )
 
-                let project = Project(name: "test", targets: [app], packages: ["XcodeGen": .local(path: "../XcodeGen")])
+                let project = Project(name: "test", targets: [app], packages: ["XcodeGen": .local(path: "../XcodeGen", group: nil)])
+
+                let pbxProject = try project.generatePbxProj(specValidate: false)
+                let nativeTarget = try unwrap(pbxProject.nativeTargets.first(where: { $0.name == app.name }))
+                let localPackageFile = try unwrap(pbxProject.fileReferences.first(where: { $0.path == "../XcodeGen" }))
+                try expect(localPackageFile.lastKnownFileType) == "folder"
+
+                let frameworkPhases = nativeTarget.buildPhases.compactMap { $0 as? PBXFrameworksBuildPhase }
+
+                guard let frameworkPhase = frameworkPhases.first else {
+                    return XCTFail("frameworkPhases should have more than one")
+                }
+
+                guard let file = frameworkPhase.files?.first else {
+                    return XCTFail("frameworkPhase should have file")
+                }
+
+                try expect(file.product?.productName) == "XcodeGen"
+            }
+            
+            
+            $0.it("generates local swift packages with custom xcode path") {
+                let app = Target(
+                    name: "MyApp",
+                    type: .application,
+                    platform: .iOS,
+                    dependencies: [
+                        Dependency(type: .package(product: nil), reference: "XcodeGen"),
+                    ]
+                )
+
+                let project = Project(name: "test", targets: [app], packages: ["XcodeGen": .local(path: "../XcodeGen", group: "Packages/Feature")])
 
                 let pbxProject = try project.generatePbxProj(specValidate: false)
                 let nativeTarget = try unwrap(pbxProject.nativeTargets.first(where: { $0.name == app.name }))

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -655,7 +655,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFileMissing(paths: ["C", "Settings.bundle", "Root.plist"])
                 try pbxProj.expectFileMissing(paths: ["C", "WithPeriod2.0"])
                 try pbxProj.expectFile(paths: ["C", "WithPeriod2.0", "file.swift"], buildPhase: .sources)
-                try pbxProj.expectFile(paths: ["C", "Documentation.docc"], buildPhase: BuildPhaseSpec.none)
+                try pbxProj.expectFile(paths: ["C", "Documentation.docc"], buildPhase: .sources)
             }
 
             $0.it("only omits the defined Info.plist from resource build phases but not other plists") {


### PR DESCRIPTION
Add update to the latest Xcodegen version - 2.28.0, that is needed for the SMP test target adding to our Xcodegen generated test targets.